### PR TITLE
perf(merge): stream whole-document output

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,20 +28,27 @@ The runtime implementation must remain qpdf-free.
 
 ## Benchmark Snapshot
 
-Measured on 2026-07-03 with local PDFs identified only by page count. Each row
-is a single run using `/usr/bin/time -l`; RSS is maximum resident set size.
-Completed outputs were validated by page count and `qpdf --warning-exit-0
---check`. Split scenarios validated the first and last output file.
+Measured on 2026-07-03 with local PDFs identified only by page count. Wall time
+is `hyperfine --warmup 1 --runs 5` mean plus standard deviation. RSS is maximum
+resident set size from a separate single `/usr/bin/time -l` run, so use it as a
+memory-order signal rather than a statistically averaged value.
 
-For rewrite and merge scenarios, qpdf used `--remove-unreferenced-resources=no`
-to measure the comparable fast copy path. The market runner-up is the fastest
-comparable non-qpdf CLI measured locally: Poppler for split workloads, MuPDF for
-rewrite and merge workloads.
+Completed outputs were validated by page count and `qpdf --warning-exit-0
+--check`. Split scenarios validated the first and last output file. qpdf used
+`--remove-unreferenced-resources=no` for copy-like paths where applicable.
 
 | Scenario | pdq | qpdf | Market runner-up | Notes |
 | --- | ---: | ---: | ---: | --- |
-| 12,732-page split into single-page PDFs | 2.04s / 245 MB | 2.96s / 1.45 GB | Poppler >60s timeout | Poppler produced 3 partial outputs before timeout. |
-| 2,642-page split into single-page PDFs | 0.64s / 146 MB | 3.63s / 907 MB | Poppler >60s timeout | Poppler produced 58 partial outputs before timeout. |
-| 12,732-page full rewrite | 0.99s / 1.03 GB | 1.53s / 417 MB | MuPDF 6.30s / 80 MB | pdq wins wall time; qpdf and MuPDF use less memory. |
-| 2,642-page full rewrite | 1.16s / 254 MB | 0.21s / 98 MB | MuPDF 0.36s / 26 MB | qpdf wins this small rewrite path. |
-| 15,374-page merge | 2.02s / 713 MB | 1.30s / 501 MB | MuPDF 9.06s / 384 MB | qpdf still wins merge wall time and RSS. |
+| 12,732-page split into single-page PDFs | 1.75s +/- 0.05s / 241 MB | 4.27s +/- 0.07s / 217 MB | Poppler >60s timeout | Poppler produced 3 partial outputs before timeout. |
+| 2,642-page split into single-page PDFs | 0.55s +/- 0.03s / 146 MB | >60s timeout | Poppler >60s timeout | qpdf produced 727 partial outputs; Poppler produced 59. |
+| 12,732-page full rewrite | 0.56s +/- 0.04s / 1.03 GB | 0.91s +/- 0.03s / 221 MB | MuPDF 0.54s +/- 0.02s / 71 MB | MuPDF narrowly wins wall time; pdq is close but uses more memory. |
+| 2,642-page full rewrite | 1.07s +/- 0.01s / 261 MB | 0.17s +/- 0.00s / 57 MB | MuPDF 0.11s +/- 0.00s / 24 MB | Small rewrite remains a qpdf/MuPDF win. |
+| 15,374-page merge | 0.71s +/- 0.01s / 230 MB | 1.36s +/- 0.04s / 495 MB | MuPDF 8.64s +/- 0.22s / 390 MB | pdq uses streaming output for whole-document merge. |
+
+To reproduce the timing matrix:
+
+```sh
+PDQ_BIG_PDF=/path/to/12732-pages.pdf \
+PDQ_SMALL_PDF=/path/to/2642-pages.pdf \
+scripts/benchmark.sh
+```

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+seuop
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+BIG_PDF=${PDQ_BIG_PDF:?set PDQ_BIG_PDF to the 12,732-page benchmark PDF}
+SMALL_PDF=${PDQ_SMALL_PDF:?set PDQ_SMALL_PDF to the 2,642-page benchmark PDF}
+RUNS=${BENCH_RUNS:-5}
+WARMUP=${BENCH_WARMUP:-1}
+TIMEOUT_SECONDS=${BENCH_TIMEOUT_SECONDS:-60}
+BENCH_DIR=${BENCH_DIR:-"$(mktemp -d /tmp/pdq-bench.XXXXXX)"}
+
+mkdir -p "$BENCH_DIR/json" "$BENCH_DIR/out"
+cargo build --release --manifest-path "$ROOT/Cargo.toml"
+
+hyperfine --warmup "$WARMUP" --runs "$RUNS" --export-json "$BENCH_DIR/json/split-big.json" \
+  --prepare "rm -rf '$BENCH_DIR/out/split-big' && mkdir -p '$BENCH_DIR/out/split-big/pdq' '$BENCH_DIR/out/split-big/qpdf'" \
+  -n pdq "$ROOT/target/release/pdq split-pages --output '$BENCH_DIR/out/split-big/pdq/page-%d.pdf' '$BIG_PDF'" \
+  -n qpdf "qpdf --remove-unreferenced-resources=no --split-pages '$BIG_PDF' '$BENCH_DIR/out/split-big/qpdf/page-%d.pdf'"
+
+hyperfine --warmup "$WARMUP" --runs "$RUNS" --export-json "$BENCH_DIR/json/split-small-pdq.json" \
+  --prepare "rm -rf '$BENCH_DIR/out/split-small-pdq' && mkdir -p '$BENCH_DIR/out/split-small-pdq'" \
+  -n pdq "$ROOT/target/release/pdq split-pages --output '$BENCH_DIR/out/split-small-pdq/page-%d.pdf' '$SMALL_PDF'"
+
+python3 - <<'PY' "$BENCH_DIR/out/split-small-qpdf-timeout" "$SMALL_PDF" "$BENCH_DIR/qpdf-split-small-timeout.txt" "$TIMEOUT_SECONDS"
+import pathlib, shutil, subprocess, sys, time
+
+outdir = pathlib.Path(sys.argv[1])
+small = sys.argv[2]
+log = pathlib.Path(sys.argv[3])
+timeout = int(sys.argv[4])
+shutil.rmtree(outdir, ignore_errors=True)
+outdir.mkdir(parents=True)
+cmd = ["qpdf", "--remove-unreferenced-resources=no", "--split-pages", small, str(outdir / "page-%d.pdf")]
+start = time.perf_counter()
+try:
+    subprocess.run(cmd, timeout=timeout, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    status = "completed"
+except subprocess.TimeoutExpired:
+    status = "timeout"
+end = time.perf_counter()
+count = len(list(outdir.glob("*.pdf")))
+log.write_text(f"status={status}\nelapsed={end-start:.3f}\noutputs={count}\ncmd={' '.join(cmd)}\n")
+print(log.read_text(), end="")
+PY
+
+hyperfine --warmup "$WARMUP" --runs "$RUNS" --export-json "$BENCH_DIR/json/rewrite-big.json" \
+  --prepare "rm -f '$BENCH_DIR/out/rewrite-big-'*.pdf" \
+  -n pdq "$ROOT/target/release/pdq split '$BIG_PDF' --out 1-z '$BENCH_DIR/out/rewrite-big-pdq.pdf'" \
+  -n qpdf "qpdf --remove-unreferenced-resources=no '$BIG_PDF' '$BENCH_DIR/out/rewrite-big-qpdf.pdf'" \
+  -n mutool "mutool clean '$BIG_PDF' '$BENCH_DIR/out/rewrite-big-mutool.pdf'"
+
+hyperfine --warmup "$WARMUP" --runs "$RUNS" --export-json "$BENCH_DIR/json/rewrite-small.json" \
+  --prepare "rm -f '$BENCH_DIR/out/rewrite-small-'*.pdf" \
+  -n pdq "$ROOT/target/release/pdq split '$SMALL_PDF' --out 1-z '$BENCH_DIR/out/rewrite-small-pdq.pdf'" \
+  -n qpdf "qpdf --remove-unreferenced-resources=no '$SMALL_PDF' '$BENCH_DIR/out/rewrite-small-qpdf.pdf'" \
+  -n mutool "mutool clean '$SMALL_PDF' '$BENCH_DIR/out/rewrite-small-mutool.pdf'"
+
+hyperfine --warmup "$WARMUP" --runs "$RUNS" --export-json "$BENCH_DIR/json/merge.json" \
+  --prepare "rm -f '$BENCH_DIR/out/merge-'*.pdf" \
+  -n pdq "$ROOT/target/release/pdq merge --output '$BENCH_DIR/out/merge-pdq.pdf' '$BIG_PDF' '$SMALL_PDF'" \
+  -n qpdf "qpdf --empty --remove-unreferenced-resources=no --pages '$BIG_PDF' '$SMALL_PDF' -- '$BENCH_DIR/out/merge-qpdf.pdf'" \
+  -n mutool "mutool merge -o '$BENCH_DIR/out/merge-mutool.pdf' '$BIG_PDF' '$SMALL_PDF'"
+
+cat <<EOF
+Benchmark data written to:
+$BENCH_DIR
+EOF

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -339,16 +339,9 @@ impl CopyContext {
                 }
                 Ok(Object::Array(copied))
             }
-            Object::Dictionary(dict) => {
-                let mut copied = lopdf::Dictionary::new();
-                for (key, value) in dict.iter() {
-                    copied.set(
-                        key.clone(),
-                        self.copy_value(source, target, value, depth + 1)?,
-                    );
-                }
-                Ok(Object::Dictionary(copied))
-            }
+            Object::Dictionary(dict) => Ok(Object::Dictionary(
+                self.copy_dictionary(source, target, dict, depth)?,
+            )),
             Object::Stream(stream) => Ok(Object::Stream(self.copy_stream(
                 source,
                 target,
@@ -427,68 +420,25 @@ impl CopyContext {
     ) -> Result<Dictionary> {
         check_copy_depth(depth)?;
         if !self.options.prune_resources || !self.prune_nested_resources || !is_form_xobject(dict) {
-            return match self.copy_value(
-                source,
-                target,
-                &Object::Dictionary(dict.clone()),
-                depth + 1,
-            )? {
-                Object::Dictionary(copied) => Ok(copied),
-                _ => unreachable!("dictionary copy returned non-dictionary"),
-            };
+            return self.copy_dictionary(source, target, dict, depth + 1);
         }
 
         let Ok(resources_value) = dict.get(b"Resources") else {
-            return match self.copy_value(
-                source,
-                target,
-                &Object::Dictionary(dict.clone()),
-                depth + 1,
-            )? {
-                Object::Dictionary(copied) => Ok(copied),
-                _ => unreachable!("dictionary copy returned non-dictionary"),
-            };
+            return self.copy_dictionary(source, target, dict, depth + 1);
         };
         let Some(resources) = self.resolve_dictionary(source, resources_value)? else {
-            return match self.copy_value(
-                source,
-                target,
-                &Object::Dictionary(dict.clone()),
-                depth + 1,
-            )? {
-                Object::Dictionary(copied) => Ok(copied),
-                _ => unreachable!("dictionary copy returned non-dictionary"),
-            };
-        };
-        let Ok(content) = stream.decompressed_content() else {
-            return match self.copy_value(
-                source,
-                target,
-                &Object::Dictionary(dict.clone()),
-                depth + 1,
-            )? {
-                Object::Dictionary(copied) => Ok(copied),
-                _ => unreachable!("dictionary copy returned non-dictionary"),
-            };
+            return self.copy_dictionary(source, target, dict, depth + 1);
         };
         let Some(used) = scan::collect_used_names_from_stream(
             source,
             stream_id,
-            &content,
+            || stream.decompressed_content().ok(),
             &resources,
             &mut self.dictionary_cache,
             &mut self.used_names_cache,
         )?
         else {
-            return match self.copy_value(
-                source,
-                target,
-                &Object::Dictionary(dict.clone()),
-                depth + 1,
-            )? {
-                Object::Dictionary(copied) => Ok(copied),
-                _ => unreachable!("dictionary copy returned non-dictionary"),
-            };
+            return self.copy_dictionary(source, target, dict, depth + 1);
         };
 
         let mut copied = Dictionary::new();
@@ -509,6 +459,24 @@ impl CopyContext {
                     self.copy_value(source, target, value, depth + 1)?,
                 );
             }
+        }
+        Ok(copied)
+    }
+
+    fn copy_dictionary(
+        &mut self,
+        source: &impl ObjectSource,
+        target: &mut Document,
+        dict: &Dictionary,
+        depth: usize,
+    ) -> Result<Dictionary> {
+        check_copy_depth(depth)?;
+        let mut copied = Dictionary::new();
+        for (key, value) in dict.iter() {
+            copied.set(
+                key.clone(),
+                self.copy_value(source, target, value, depth + 1)?,
+            );
         }
         Ok(copied)
     }
@@ -737,11 +705,20 @@ pub(crate) fn copy_pages(
     target: &mut Document,
     page_ids: &[ObjectId],
 ) -> Result<Vec<ObjectId>> {
+    copy_pages_with_options(source, target, page_ids, CopyOptions::default())
+}
+
+pub(crate) fn copy_pages_with_options(
+    source: &impl ObjectSource,
+    target: &mut Document,
+    page_ids: &[ObjectId],
+    options: CopyOptions,
+) -> Result<Vec<ObjectId>> {
     let mut copied_pages = Vec::with_capacity(page_ids.len());
     // Annotation preservation is intentionally deferred because annotation
     // dictionaries often contain page/document backreferences that need
     // careful remapping.
-    let mut context = CopyContext::new(CopyOptions::default());
+    let mut context = CopyContext::new(options);
 
     for page_id in page_ids {
         copied_pages.push(context.copy_page(source, target, *page_id)?);

--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -124,29 +124,30 @@ impl<'a> LazyPdf<'a> {
         id: ObjectId,
         container: u32,
     ) -> std::result::Result<Object, lopdf::Error> {
-        if let Some(object) = self
-            .object_streams
-            .lock()
-            .expect("object stream cache mutex poisoned")
-            .get(container, id)
-        {
-            return Ok(object);
-        }
-
-        let container_id = (container, 0);
-        let mut already_seen = HashSet::new();
-        let container_object = self.reader.get_object(container_id, &mut already_seen)?;
-        let mut container_stream = container_object.as_stream()?.clone();
-        let object_stream = Arc::new(ObjectStream::new(&mut container_stream)?.objects);
-        let object = object_stream
+        let cached_objects = {
+            self.object_streams
+                .lock()
+                .expect("object stream cache mutex poisoned")
+                .get(container)
+        };
+        let objects = if let Some(objects) = cached_objects {
+            objects
+        } else {
+            let container_id = (container, 0);
+            let mut already_seen = HashSet::new();
+            let container_object = self.reader.get_object(container_id, &mut already_seen)?;
+            let mut container_stream = container_object.as_stream()?.clone();
+            let object_stream = Arc::new(ObjectStream::new(&mut container_stream)?.objects);
+            self.object_streams
+                .lock()
+                .expect("object stream cache mutex poisoned")
+                .insert(container, Arc::clone(&object_stream));
+            object_stream
+        };
+        objects
             .get(&(id.0, 0))
             .cloned()
-            .ok_or(lopdf::Error::MissingXrefEntry)?;
-        self.object_streams
-            .lock()
-            .expect("object stream cache mutex poisoned")
-            .insert(container, object_stream);
-        Ok(object)
+            .ok_or(lopdf::Error::MissingXrefEntry)
     }
 }
 
@@ -203,15 +204,15 @@ struct ObjectStreamCache {
 }
 
 impl ObjectStreamCache {
-    fn get(&mut self, container: u32, id: ObjectId) -> Option<Object> {
+    fn get(&mut self, container: u32) -> Option<Arc<BTreeMap<ObjectId, Object>>> {
         let index = self
             .entries
             .iter()
             .position(|(cached_container, _)| *cached_container == container)?;
         let (cached_container, objects) = self.entries.remove(index)?;
-        let object = objects.get(&(id.0, 0)).cloned();
-        self.entries.push_back((cached_container, objects));
-        object
+        self.entries
+            .push_back((cached_container, Arc::clone(&objects)));
+        Some(objects)
     }
 
     fn insert(&mut self, container: u32, objects: Arc<BTreeMap<ObjectId, Object>>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod merge;
 pub mod range;
 mod scan;
 pub mod split;
+mod write;
 
 pub use copy::{CopyContext, CopyOptions};
 pub use merge::{merge, merge_with_options, MergeInput, MergeOptions};

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,15 +1,17 @@
 use std::{
-    fs,
+    fs::{self, OpenOptions},
     os::unix::fs::MetadataExt,
     path::{Path, PathBuf},
+    process,
 };
 
 use crate::{
-    copy::copy_pages,
+    copy::{copy_pages_with_options, CopyOptions},
     lazy::LazyPdf,
     load::map_file,
     range::{PageRangeError, PageRangeGroup},
     split::{empty_document, finish_pages},
+    write::{StreamingCopyContext, StreamingPdfWriter},
     PdfOpsError, Result,
 };
 
@@ -54,6 +56,10 @@ pub fn merge_with_options(
         }
     }
 
+    if inputs.iter().all(|input| input.ranges.is_empty()) {
+        return merge_whole_inputs_streaming(inputs, output);
+    }
+
     let mut target = empty_document();
     let mut merged_pages = Vec::new();
 
@@ -62,12 +68,89 @@ pub fn merge_with_options(
         let source = LazyPdf::parse(&mmap, &input.path)?;
         let pages = source.page_ids()?;
         let page_ids = resolve_merge_page_ids(&pages, input)?;
-        merged_pages.extend(copy_pages(&source, &mut target, &page_ids)?);
+        merged_pages.extend(copy_pages_with_options(
+            &source,
+            &mut target,
+            &page_ids,
+            CopyOptions {
+                prune_resources: !input.ranges.is_empty(),
+                ..CopyOptions::default()
+            },
+        )?);
     }
 
     finish_pages(&mut target, &merged_pages)?;
     target.save(output)?;
     Ok(())
+}
+
+fn merge_whole_inputs_streaming(inputs: &[MergeInput], output: &Path) -> Result<()> {
+    let temp_output = temp_output_path(output)?;
+    let result = merge_whole_inputs_streaming_to_path(inputs, &temp_output);
+    match result {
+        Ok(()) => {
+            fs::rename(&temp_output, output)?;
+            Ok(())
+        }
+        Err(err) => {
+            let _ = fs::remove_file(&temp_output);
+            Err(err)
+        }
+    }
+}
+
+fn merge_whole_inputs_streaming_to_path(inputs: &[MergeInput], output: &Path) -> Result<()> {
+    let mut writer = StreamingPdfWriter::create(output)?;
+
+    for input in inputs {
+        let mmap = map_file(&input.path)?;
+        let source = LazyPdf::parse(&mmap, &input.path)?;
+        let page_ids = source.page_ids()?;
+        if page_ids.is_empty() {
+            return Err(PdfOpsError::Range(PageRangeError::NoPages));
+        }
+
+        let copied_pages = {
+            let mut context = StreamingCopyContext::new(
+                &mut writer,
+                CopyOptions {
+                    prune_resources: false,
+                    ..CopyOptions::default()
+                },
+            );
+            context.copy_pages(&source, &page_ids)?
+        };
+        writer.extend_pages(copied_pages);
+    }
+
+    writer.finish()
+}
+
+fn temp_output_path(output: &Path) -> Result<PathBuf> {
+    let directory = output.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = output
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("pdq-output");
+    for attempt in 0..1000 {
+        let candidate = directory.join(format!(".{file_name}.pdq-{}-{attempt}.tmp", process::id()));
+        match OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&candidate)
+        {
+            Ok(_) => {
+                fs::remove_file(&candidate)?;
+                return Ok(candidate);
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(err) => return Err(err.into()),
+        }
+    }
+    Err(PdfOpsError::InvalidStructure(format!(
+        "could not allocate temporary output next to {}",
+        output.display()
+    )))
 }
 
 fn copy_whole_input(input: &MergeInput, output: &Path) -> Result<()> {

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -72,13 +72,20 @@ pub(crate) fn collect_used_names(
         dictionary_cache,
         used_names_cache,
     };
-    collect_used_names_from_bytes_with_options(source, None, &content, resources, &mut state, false)
+    collect_used_names_from_bytes_with_options(
+        source,
+        content.stream_id,
+        || Some(content.data),
+        resources,
+        &mut state,
+        false,
+    )
 }
 
 pub(crate) fn collect_used_names_from_stream(
     source: &impl ObjectSource,
     stream_id: Option<ObjectId>,
-    content: &[u8],
+    content: impl FnOnce() -> Option<Vec<u8>>,
     resources: &Dictionary,
     dictionary_cache: &mut BTreeMap<ObjectId, Rc<Dictionary>>,
     used_names_cache: &mut BTreeMap<ObjectId, Option<UsedNames>>,
@@ -95,12 +102,12 @@ pub(crate) fn collect_used_names_from_stream(
 fn collect_used_names_from_bytes_with_options(
     source: &impl ObjectSource,
     stream_id: Option<ObjectId>,
-    content: &[u8],
+    content: impl FnOnce() -> Option<Vec<u8>>,
     resources: &Dictionary,
     state: &mut ScanState<'_>,
     strict_own_form_failures: bool,
 ) -> Result<Option<UsedNames>> {
-    let Some(mut used) = scan_names_cached(content, stream_id, state.used_names_cache) else {
+    let Some(mut used) = scan_names_cached(stream_id, state.used_names_cache, content) else {
         return Ok(None);
     };
     if !all_named_resources_resolve(source, resources, b"Font", &used.fonts, state)? {
@@ -159,13 +166,9 @@ fn collect_form_names(
             }
         }
 
-        let Ok(content) = stream.decompressed_content() else {
-            if strict_own_form_failures {
-                return Ok(false);
-            }
-            continue;
-        };
-        let Some(form_used) = scan_names_cached(&content, id, state.used_names_cache) else {
+        let Some(form_used) = scan_names_cached(id, state.used_names_cache, || {
+            stream.decompressed_content().ok()
+        }) else {
             if strict_own_form_failures {
                 return Ok(false);
             }
@@ -222,18 +225,18 @@ fn collect_form_names(
 fn scan_names(data: &[u8]) -> Option<UsedNames> {
     let content = Content::decode_strict(data).ok()?;
     let mut used = UsedNames::default();
-    let mut last_name: Option<Vec<u8>> = None;
+    let mut last_name: Option<&[u8]> = None;
 
-    for operation in content.operations {
+    for operation in &content.operations {
         for operand in &operation.operands {
             if let Object::Name(name) = operand {
-                last_name = Some(name.clone());
+                last_name = Some(name);
             }
         }
         let Some(resource_type) = resource_type_for_operator(&operation.operator) else {
             continue;
         };
-        let Some(name) = last_name.as_deref() else {
+        let Some(name) = last_name else {
             continue;
         };
         used.insert(resource_type, name);
@@ -243,17 +246,18 @@ fn scan_names(data: &[u8]) -> Option<UsedNames> {
 }
 
 fn scan_names_cached(
-    data: &[u8],
     stream_id: Option<ObjectId>,
     used_names_cache: &mut BTreeMap<ObjectId, Option<UsedNames>>,
+    content: impl FnOnce() -> Option<Vec<u8>>,
 ) -> Option<UsedNames> {
     let Some(stream_id) = stream_id else {
-        return scan_names(data);
+        return scan_names(&content()?);
     };
     if let Some(cached) = used_names_cache.get(&stream_id) {
         return cached.clone();
     }
-    let used = scan_names(data);
+    let data = content()?;
+    let used = scan_names(&data);
     used_names_cache.insert(stream_id, used.clone());
     used
 }
@@ -271,18 +275,25 @@ fn resource_type_for_operator(operator: &str) -> Option<ResourceType> {
     }
 }
 
-fn content_bytes(source: &impl ObjectSource, page: &Dictionary) -> Result<Option<Vec<u8>>> {
+struct ContentBytes {
+    stream_id: Option<ObjectId>,
+    data: Vec<u8>,
+}
+
+fn content_bytes(source: &impl ObjectSource, page: &Dictionary) -> Result<Option<ContentBytes>> {
     let Ok(contents) = page.get(b"Contents") else {
-        return Ok(Some(Vec::new()));
+        return Ok(Some(ContentBytes {
+            stream_id: None,
+            data: Vec::new(),
+        }));
     };
-    let mut data = Vec::new();
     match contents {
-        Object::Reference(id) => {
-            if append_content_stream(source, *id, &mut data)?.is_none() {
-                return Ok(None);
-            }
-        }
+        Object::Reference(id) => Ok(content_stream_bytes(source, *id)?.map(|data| ContentBytes {
+            stream_id: Some(*id),
+            data,
+        })),
         Object::Array(items) => {
+            let mut data = Vec::new();
             for item in items {
                 let Object::Reference(id) = item else {
                     return Ok(None);
@@ -292,16 +303,22 @@ fn content_bytes(source: &impl ObjectSource, page: &Dictionary) -> Result<Option
                 }
                 data.push(b'\n');
             }
+            Ok(Some(ContentBytes {
+                stream_id: None,
+                data,
+            }))
         }
         Object::Stream(stream) => {
             let Ok(decoded) = stream.decompressed_content() else {
                 return Ok(None);
             };
-            data.extend(decoded);
+            Ok(Some(ContentBytes {
+                stream_id: None,
+                data: decoded,
+            }))
         }
-        _ => return Ok(None),
+        _ => Ok(None),
     }
-    Ok(Some(data))
 }
 
 fn append_content_stream(
@@ -309,6 +326,14 @@ fn append_content_stream(
     id: ObjectId,
     data: &mut Vec<u8>,
 ) -> Result<Option<()>> {
+    let Some(decoded) = content_stream_bytes(source, id)? else {
+        return Ok(None);
+    };
+    data.extend(decoded);
+    Ok(Some(()))
+}
+
+fn content_stream_bytes(source: &impl ObjectSource, id: ObjectId) -> Result<Option<Vec<u8>>> {
     let object = match source.get_object_value(id) {
         Ok(object) => object,
         Err(lopdf::Error::ObjectNotFound(_)) => return Ok(None),
@@ -320,8 +345,7 @@ fn append_content_stream(
     let Ok(decoded) = stream.decompressed_content() else {
         return Ok(None);
     };
-    data.extend(decoded);
-    Ok(Some(()))
+    Ok(Some(decoded))
 }
 
 fn named_resource_object(

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,0 +1,632 @@
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet},
+    fs::{File, OpenOptions},
+    io::{BufWriter, Write},
+    path::Path,
+    rc::Rc,
+};
+
+use lopdf::{dictionary, Dictionary, Object, ObjectId, StringFormat};
+
+use crate::{
+    copy::{CopyOptions, ObjectSource},
+    PdfOpsError, Result,
+};
+
+const INHERITABLE_PAGE_ATTRS: [&[u8]; 4] = [b"Resources", b"MediaBox", b"CropBox", b"Rotate"];
+const MAX_COPY_DEPTH: usize = 256;
+
+pub(crate) struct StreamingPdfWriter {
+    output: CountingWriter<BufWriter<File>>,
+    offsets: BTreeMap<u32, u32>,
+    max_id: u32,
+    pages_id: ObjectId,
+    catalog_id: ObjectId,
+    pages: Vec<ObjectId>,
+}
+
+impl StreamingPdfWriter {
+    pub(crate) fn create(path: &Path) -> Result<Self> {
+        let file = OpenOptions::new().write(true).create_new(true).open(path)?;
+        let mut output = CountingWriter::new(BufWriter::new(file));
+        output.write_all(b"%PDF-1.7\n%\xC7\xEC\x8F\xA2\n")?;
+
+        let mut writer = Self {
+            output,
+            offsets: BTreeMap::new(),
+            max_id: 0,
+            pages_id: (0, 0),
+            catalog_id: (0, 0),
+            pages: Vec::new(),
+        };
+        writer.pages_id = writer.new_object_id();
+        writer.catalog_id = writer.new_object_id();
+        Ok(writer)
+    }
+
+    pub(crate) fn new_object_id(&mut self) -> ObjectId {
+        self.max_id += 1;
+        (self.max_id, 0)
+    }
+
+    pub(crate) fn pages_id(&self) -> ObjectId {
+        self.pages_id
+    }
+
+    pub(crate) fn extend_pages(&mut self, pages: impl IntoIterator<Item = ObjectId>) {
+        self.pages.extend(pages);
+    }
+
+    pub(crate) fn write_object(&mut self, id: ObjectId, object: &Object) -> Result<()> {
+        let offset = u32::try_from(self.output.bytes_written()).map_err(|_| {
+            PdfOpsError::InvalidStructure("streaming output offset exceeds PDF xref limit".into())
+        })?;
+        self.offsets.insert(id.0, offset);
+        write!(self.output, "{} {} obj\n", id.0, id.1)?;
+        write_object(&mut self.output, object)?;
+        self.output.write_all(b"\nendobj\n")?;
+        Ok(())
+    }
+
+    pub(crate) fn finish(mut self) -> Result<()> {
+        let kids = self
+            .pages
+            .iter()
+            .copied()
+            .map(Object::Reference)
+            .collect::<Vec<_>>();
+        let pages = dictionary! {
+            "Type" => "Pages",
+            "Kids" => Object::Array(kids),
+            "Count" => self.pages.len() as i64,
+        };
+        self.write_object(self.pages_id, &Object::Dictionary(pages))?;
+
+        let catalog = dictionary! {
+            "Type" => "Catalog",
+            "Pages" => self.pages_id,
+        };
+        self.write_object(self.catalog_id, &Object::Dictionary(catalog))?;
+
+        let xref_start = self.output.bytes_written();
+        self.output.write_all(b"xref\n")?;
+        writeln!(self.output, "0 {}", self.max_id + 1)?;
+        self.output.write_all(b"0000000000 65535 f \n")?;
+        for id in 1..=self.max_id {
+            let offset = self.offsets.get(&id).copied().ok_or_else(|| {
+                PdfOpsError::InvalidStructure(format!("missing xref offset for object {id}"))
+            })?;
+            writeln!(self.output, "{offset:010} 00000 n ")?;
+        }
+        self.output.write_all(b"trailer\n")?;
+        let trailer = dictionary! {
+            "Size" => (self.max_id + 1) as i64,
+            "Root" => self.catalog_id,
+        };
+        write_dictionary(&mut self.output, &trailer)?;
+        write!(self.output, "\nstartxref\n{xref_start}\n%%EOF")?;
+        self.output.flush()?;
+        Ok(())
+    }
+}
+
+pub(crate) struct StreamingCopyContext<'a> {
+    writer: &'a mut StreamingPdfWriter,
+    object_map: BTreeMap<ObjectId, ObjectId>,
+    inherited_attrs_cache: BTreeMap<ObjectId, Rc<InheritedPageAttrs>>,
+    selected_pages: BTreeSet<ObjectId>,
+    options: CopyOptions,
+}
+
+impl<'a> StreamingCopyContext<'a> {
+    pub(crate) fn new(writer: &'a mut StreamingPdfWriter, options: CopyOptions) -> Self {
+        Self {
+            writer,
+            object_map: BTreeMap::new(),
+            inherited_attrs_cache: BTreeMap::new(),
+            selected_pages: BTreeSet::new(),
+            options,
+        }
+    }
+
+    pub(crate) fn copy_pages(
+        &mut self,
+        source: &impl ObjectSource,
+        page_ids: &[ObjectId],
+    ) -> Result<Vec<ObjectId>> {
+        let mut copied_pages = Vec::with_capacity(page_ids.len());
+        for page_id in page_ids {
+            copied_pages.push(self.copy_page(source, *page_id)?);
+        }
+        Ok(copied_pages)
+    }
+
+    fn copy_page(&mut self, source: &impl ObjectSource, page_id: ObjectId) -> Result<ObjectId> {
+        let new_id = if self.selected_pages.contains(&page_id) {
+            self.copy_page_instance(source, page_id)?
+        } else {
+            let new_id = self.copy_object_at_depth(source, page_id, 0)?;
+            self.selected_pages.insert(page_id);
+            new_id
+        };
+        Ok(new_id)
+    }
+
+    fn copy_page_instance(
+        &mut self,
+        source: &impl ObjectSource,
+        old_page_id: ObjectId,
+    ) -> Result<ObjectId> {
+        let object = source
+            .get_object_value(old_page_id)
+            .map_err(PdfOpsError::Pdf)?;
+        let page = object
+            .as_dict()
+            .map_err(|_| PdfOpsError::InvalidStructure("page is not a dictionary".into()))?;
+        if !page.has_type(b"Page") {
+            return Err(PdfOpsError::InvalidStructure(
+                "copied page does not have /Type /Page".into(),
+            ));
+        }
+
+        let new_id = self.writer.new_object_id();
+        let previous = self.object_map.insert(old_page_id, new_id);
+        let copied = match self.copy_page_dictionary(source, old_page_id, page, 0) {
+            Ok(copied) => copied,
+            Err(err) => {
+                restore_object_mapping(&mut self.object_map, old_page_id, previous);
+                return Err(err);
+            }
+        };
+        self.writer
+            .write_object(new_id, &Object::Dictionary(copied))?;
+        restore_object_mapping(&mut self.object_map, old_page_id, previous);
+        Ok(new_id)
+    }
+
+    fn copy_object_at_depth(
+        &mut self,
+        source: &impl ObjectSource,
+        old_id: ObjectId,
+        depth: usize,
+    ) -> Result<ObjectId> {
+        check_copy_depth(depth)?;
+        if let Some(new_id) = self.object_map.get(&old_id) {
+            return Ok(*new_id);
+        }
+
+        let new_id = self.writer.new_object_id();
+        self.object_map.insert(old_id, new_id);
+
+        let object = match source.get_object_value(old_id) {
+            Ok(object) => object,
+            Err(lopdf::Error::ObjectNotFound(_)) => {
+                self.writer.write_object(new_id, &Object::Null)?;
+                return Ok(new_id);
+            }
+            Err(err) => return Err(PdfOpsError::Pdf(err)),
+        };
+
+        let copied = match object {
+            Cow::Borrowed(object) => match object {
+                Object::Dictionary(dict) if dict.has_type(b"Page") => Object::Dictionary(
+                    self.copy_page_dictionary(source, old_id, dict, depth + 1)?,
+                ),
+                Object::Stream(stream) => {
+                    Object::Stream(self.copy_stream(source, stream.clone(), depth + 1)?)
+                }
+                _ => self.copy_value(source, object, depth + 1)?,
+            },
+            Cow::Owned(object) => match object {
+                Object::Dictionary(dict) if dict.has_type(b"Page") => Object::Dictionary(
+                    self.copy_page_dictionary(source, old_id, &dict, depth + 1)?,
+                ),
+                Object::Stream(stream) => {
+                    Object::Stream(self.copy_stream(source, stream, depth + 1)?)
+                }
+                object => self.copy_owned_value(source, object, depth + 1)?,
+            },
+        };
+        self.writer.write_object(new_id, &copied)?;
+        Ok(new_id)
+    }
+
+    fn copy_page_dictionary(
+        &mut self,
+        source: &impl ObjectSource,
+        old_page_id: ObjectId,
+        page: &Dictionary,
+        depth: usize,
+    ) -> Result<Dictionary> {
+        check_copy_depth(depth)?;
+        let mut copied = Dictionary::new();
+        for (key, value) in page.iter() {
+            if key.as_slice() == b"Parent" {
+                continue;
+            }
+            if key.as_slice() == b"Annots" && !self.options.copy_annotations {
+                continue;
+            }
+            copied.set(key.clone(), self.copy_value(source, value, depth + 1)?);
+        }
+
+        for key in INHERITABLE_PAGE_ATTRS {
+            if copied.has(key) {
+                continue;
+            }
+            if let Some(value) = self.inherited_attr(source, old_page_id, page, key)? {
+                copied.set(key.to_vec(), self.copy_value(source, &value, depth + 1)?);
+            }
+        }
+        copied.set("Parent", self.writer.pages_id());
+
+        Ok(copied)
+    }
+
+    fn copy_value(
+        &mut self,
+        source: &impl ObjectSource,
+        value: &Object,
+        depth: usize,
+    ) -> Result<Object> {
+        check_copy_depth(depth)?;
+        match value {
+            Object::Reference(id) => Ok(Object::Reference(self.copy_object_at_depth(
+                source,
+                *id,
+                depth + 1,
+            )?)),
+            Object::Array(items) => {
+                let mut copied = Vec::with_capacity(items.len());
+                for item in items {
+                    copied.push(self.copy_value(source, item, depth + 1)?);
+                }
+                Ok(Object::Array(copied))
+            }
+            Object::Dictionary(dict) => {
+                let mut copied = Dictionary::new();
+                for (key, value) in dict.iter() {
+                    copied.set(key.clone(), self.copy_value(source, value, depth + 1)?);
+                }
+                Ok(Object::Dictionary(copied))
+            }
+            Object::Stream(stream) => Ok(Object::Stream(self.copy_stream(
+                source,
+                stream.clone(),
+                depth + 1,
+            )?)),
+            _ => Ok(value.clone()),
+        }
+    }
+
+    fn copy_owned_value(
+        &mut self,
+        source: &impl ObjectSource,
+        value: Object,
+        depth: usize,
+    ) -> Result<Object> {
+        check_copy_depth(depth)?;
+        match value {
+            Object::Reference(id) => Ok(Object::Reference(self.copy_object_at_depth(
+                source,
+                id,
+                depth + 1,
+            )?)),
+            Object::Array(items) => {
+                let mut copied = Vec::with_capacity(items.len());
+                for item in items {
+                    copied.push(self.copy_owned_value(source, item, depth + 1)?);
+                }
+                Ok(Object::Array(copied))
+            }
+            Object::Dictionary(dict) => {
+                let mut copied = Dictionary::new();
+                for (key, value) in dict {
+                    copied.set(key, self.copy_owned_value(source, value, depth + 1)?);
+                }
+                Ok(Object::Dictionary(copied))
+            }
+            Object::Stream(stream) => Ok(Object::Stream(self.copy_stream(
+                source,
+                stream,
+                depth + 1,
+            )?)),
+            value => Ok(value),
+        }
+    }
+
+    fn copy_stream(
+        &mut self,
+        source: &impl ObjectSource,
+        mut stream: lopdf::Stream,
+        depth: usize,
+    ) -> Result<lopdf::Stream> {
+        stream.dict = self.copy_dictionary(source, &stream.dict, depth + 1)?;
+        Ok(stream)
+    }
+
+    fn copy_dictionary(
+        &mut self,
+        source: &impl ObjectSource,
+        dict: &Dictionary,
+        depth: usize,
+    ) -> Result<Dictionary> {
+        check_copy_depth(depth)?;
+        let mut copied = Dictionary::new();
+        for (key, value) in dict.iter() {
+            copied.set(key.clone(), self.copy_value(source, value, depth + 1)?);
+        }
+        Ok(copied)
+    }
+
+    fn inherited_attr(
+        &mut self,
+        source: &impl ObjectSource,
+        page_id: ObjectId,
+        page: &Dictionary,
+        key: &[u8],
+    ) -> Result<Option<Object>> {
+        if let Ok(value) = page.get(key) {
+            return Ok(Some(value.clone()));
+        }
+
+        let mut current = match page.get(b"Parent") {
+            Ok(Object::Reference(parent)) => *parent,
+            Ok(_) => {
+                return Err(PdfOpsError::InvalidStructure(
+                    "page tree parent is not a reference".into(),
+                ));
+            }
+            Err(_) => return Ok(None),
+        };
+        let mut visited = BTreeSet::from([page_id]);
+
+        loop {
+            if !visited.insert(current) {
+                return Err(PdfOpsError::InvalidStructure(
+                    "cycle detected while resolving inherited page attributes".into(),
+                ));
+            }
+
+            let Some(attrs) = self.inherited_attrs(source, current)? else {
+                return Ok(None);
+            };
+            if let Some(value) = attrs.get(key) {
+                return Ok(Some(value.clone()));
+            }
+            match attrs.parent {
+                ParentRef::Reference(parent) => current = parent,
+                ParentRef::Missing => return Ok(None),
+                ParentRef::Invalid => {
+                    return Err(PdfOpsError::InvalidStructure(
+                        "page tree parent is not a reference".into(),
+                    ));
+                }
+            }
+        }
+    }
+
+    fn inherited_attrs(
+        &mut self,
+        source: &impl ObjectSource,
+        id: ObjectId,
+    ) -> Result<Option<Rc<InheritedPageAttrs>>> {
+        if let Some(attrs) = self.inherited_attrs_cache.get(&id) {
+            return Ok(Some(Rc::clone(attrs)));
+        }
+
+        let object = match source.get_object_value(id) {
+            Ok(object) => object,
+            Err(lopdf::Error::ObjectNotFound(_)) => return Ok(None),
+            Err(err) => return Err(PdfOpsError::Pdf(err)),
+        };
+        let dict = object.as_dict().map_err(|_| {
+            PdfOpsError::InvalidStructure("page tree node is not a dictionary".into())
+        })?;
+        let attrs = Rc::new(InheritedPageAttrs::from_dict(dict));
+        self.inherited_attrs_cache.insert(id, Rc::clone(&attrs));
+        Ok(Some(attrs))
+    }
+}
+
+#[derive(Debug, Default)]
+struct InheritedPageAttrs {
+    resources: Option<Object>,
+    media_box: Option<Object>,
+    crop_box: Option<Object>,
+    rotate: Option<Object>,
+    parent: ParentRef,
+}
+
+impl InheritedPageAttrs {
+    fn from_dict(dict: &Dictionary) -> Self {
+        Self {
+            resources: dict.get(b"Resources").ok().cloned(),
+            media_box: dict.get(b"MediaBox").ok().cloned(),
+            crop_box: dict.get(b"CropBox").ok().cloned(),
+            rotate: dict.get(b"Rotate").ok().cloned(),
+            parent: match dict.get(b"Parent") {
+                Ok(Object::Reference(parent)) => ParentRef::Reference(*parent),
+                Ok(_) => ParentRef::Invalid,
+                Err(_) => ParentRef::Missing,
+            },
+        }
+    }
+
+    fn get(&self, key: &[u8]) -> Option<&Object> {
+        match key {
+            b"Resources" => self.resources.as_ref(),
+            b"MediaBox" => self.media_box.as_ref(),
+            b"CropBox" => self.crop_box.as_ref(),
+            b"Rotate" => self.rotate.as_ref(),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+enum ParentRef {
+    Reference(ObjectId),
+    #[default]
+    Missing,
+    Invalid,
+}
+
+fn restore_object_mapping(
+    object_map: &mut BTreeMap<ObjectId, ObjectId>,
+    old_id: ObjectId,
+    previous: Option<ObjectId>,
+) {
+    if let Some(previous) = previous {
+        object_map.insert(old_id, previous);
+    } else {
+        object_map.remove(&old_id);
+    }
+}
+
+fn check_copy_depth(depth: usize) -> Result<()> {
+    if depth > MAX_COPY_DEPTH {
+        return Err(PdfOpsError::InvalidStructure(format!(
+            "PDF object nesting exceeds maximum copy depth of {MAX_COPY_DEPTH}"
+        )));
+    }
+    Ok(())
+}
+
+fn write_object(output: &mut dyn Write, object: &Object) -> std::io::Result<()> {
+    match object {
+        Object::Null => output.write_all(b"null"),
+        Object::Boolean(value) => {
+            if *value {
+                output.write_all(b"true")
+            } else {
+                output.write_all(b"false")
+            }
+        }
+        Object::Integer(value) => write!(output, "{value}"),
+        Object::Real(value) => write!(output, "{value}"),
+        Object::Name(name) => write_name(output, name),
+        Object::String(text, format) => write_string(output, text, *format),
+        Object::Array(items) => write_array(output, items),
+        Object::Dictionary(dict) => write_dictionary(output, dict),
+        Object::Stream(stream) => write_stream(output, stream),
+        Object::Reference(id) => write!(output, "{} {} R", id.0, id.1),
+    }
+}
+
+fn write_name(output: &mut dyn Write, name: &[u8]) -> std::io::Result<()> {
+    output.write_all(b"/")?;
+    for &byte in name {
+        if b" \t\n\r\x0C()<>[]{}/%#".contains(&byte) || !(33..=126).contains(&byte) {
+            write!(output, "#{byte:02X}")?;
+        } else {
+            output.write_all(&[byte])?;
+        }
+    }
+    Ok(())
+}
+
+fn write_string(output: &mut dyn Write, text: &[u8], format: StringFormat) -> std::io::Result<()> {
+    match format {
+        StringFormat::Literal => {
+            output.write_all(b"(")?;
+            for &byte in text {
+                match byte {
+                    b'(' => output.write_all(b"\\(")?,
+                    b')' => output.write_all(b"\\)")?,
+                    b'\\' => output.write_all(b"\\\\")?,
+                    b'\r' => output.write_all(b"\\r")?,
+                    byte => output.write_all(&[byte])?,
+                }
+            }
+            output.write_all(b")")
+        }
+        StringFormat::Hexadecimal => {
+            output.write_all(b"<")?;
+            for &byte in text {
+                write!(output, "{byte:02X}")?;
+            }
+            output.write_all(b">")
+        }
+    }
+}
+
+fn write_array(output: &mut dyn Write, items: &[Object]) -> std::io::Result<()> {
+    output.write_all(b"[")?;
+    let mut first = true;
+    for item in items {
+        if first {
+            first = false;
+        } else if needs_separator(item) {
+            output.write_all(b" ")?;
+        }
+        write_object(output, item)?;
+    }
+    output.write_all(b"]")
+}
+
+fn write_dictionary(output: &mut dyn Write, dictionary: &Dictionary) -> std::io::Result<()> {
+    output.write_all(b"<<")?;
+    for (key, value) in dictionary {
+        write_name(output, key)?;
+        if needs_separator(value) {
+            output.write_all(b" ")?;
+        }
+        write_object(output, value)?;
+    }
+    output.write_all(b">>")
+}
+
+fn write_stream(output: &mut dyn Write, stream: &lopdf::Stream) -> std::io::Result<()> {
+    write_dictionary(output, &stream.dict)?;
+    output.write_all(b"stream\n")?;
+    output.write_all(&stream.content)?;
+    output.write_all(b"\nendstream")
+}
+
+fn needs_separator(object: &Object) -> bool {
+    matches!(
+        object,
+        Object::Null
+            | Object::Boolean(_)
+            | Object::Integer(_)
+            | Object::Real(_)
+            | Object::Reference(_)
+    )
+}
+
+struct CountingWriter<W: Write> {
+    inner: W,
+    bytes_written: usize,
+}
+
+impl<W: Write> CountingWriter<W> {
+    fn new(inner: W) -> Self {
+        Self {
+            inner,
+            bytes_written: 0,
+        }
+    }
+
+    fn bytes_written(&self) -> usize {
+        self.bytes_written
+    }
+}
+
+impl<W: Write> Write for CountingWriter<W> {
+    fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+        let bytes = self.inner.write(buffer)?;
+        self.bytes_written += bytes;
+        Ok(bytes)
+    }
+
+    fn write_all(&mut self, buffer: &[u8]) -> std::io::Result<()> {
+        self.bytes_written += buffer.len();
+        self.inner.write_all(buffer)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}

--- a/tests/split_merge.rs
+++ b/tests/split_merge.rs
@@ -365,6 +365,44 @@ fn split_pages_prunes_shared_page_resources() {
 }
 
 #[test]
+fn merge_whole_document_keeps_shared_page_resources() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("shared-resources.pdf");
+    let merged = temp.path().join("merged.pdf");
+
+    write_shared_resources_fixture(&input, false);
+    merge(&[MergeInput::all(&input)], &merged).unwrap();
+
+    assert_page_resources_in_document(
+        &merged,
+        &QpdfValidator::detect(),
+        3,
+        1,
+        &["X0", "X1", "X2", "X3", "X4", "X5", "X6"],
+        &["F1"],
+    );
+}
+
+#[test]
+fn merge_selected_ranges_prunes_shared_page_resources() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("shared-resources.pdf");
+    let merged = temp.path().join("merged-range.pdf");
+
+    write_shared_resources_fixture(&input, false);
+    merge(
+        &[MergeInput {
+            path: input,
+            ranges: vec![PageRangeGroup::parse("1").unwrap()],
+        }],
+        &merged,
+    )
+    .unwrap();
+
+    assert_page_resources(&merged, &QpdfValidator::detect(), &["X0"], &[]);
+}
+
+#[test]
 fn split_pages_falls_back_when_content_stream_is_malformed() {
     let temp = tempdir().unwrap();
     let input = temp.path().join("malformed-content.pdf");
@@ -763,16 +801,27 @@ fn write_form_font_fixture(path: &Path, form_has_own_resources: bool) {
 }
 
 fn assert_page_resources(path: &Path, qpdf: &QpdfValidator, xobjects: &[&str], fonts: &[&str]) {
+    assert_page_resources_in_document(path, qpdf, 1, 1, xobjects, fonts);
+}
+
+fn assert_page_resources_in_document(
+    path: &Path,
+    qpdf: &QpdfValidator,
+    expected_pages: usize,
+    page_number: u32,
+    xobjects: &[&str],
+    fonts: &[&str],
+) {
     assert_written(path);
-    qpdf.validate(path, 1);
+    qpdf.validate(path, expected_pages);
 
     let document = Document::load(path)
         .unwrap_or_else(|err| panic!("failed to load split output {}: {err}", path.display()));
     let pages = document.get_pages();
     let page_id = pages
-        .get(&1)
+        .get(&page_number)
         .copied()
-        .unwrap_or_else(|| panic!("missing page 1 in {}", path.display()));
+        .unwrap_or_else(|| panic!("missing page {page_number} in {}", path.display()));
     let page = document
         .get_object(page_id)
         .unwrap_or_else(|err| panic!("failed to read page object {}: {err}", path.display()))


### PR DESCRIPTION
## Summary
- add a streaming writer path for whole-document merge outputs
- skip resource pruning for whole-document merge while preserving pruning for ranged merge/split
- add a reproducible hyperfine benchmark script and refresh the README benchmark snapshot

## Validation
- bash -n scripts/benchmark.sh
- cargo fmt
- cargo test
- cargo build --release
- git diff --check
- qpdf --warning-exit-0 --check on benchmark outputs

## Benchmark highlights
- 15,374-page merge: pdq 0.71s +/- 0.01s / 230 MB RSS
- qpdf no-prune merge: 1.36s +/- 0.04s / 495 MB RSS
- mutool merge: 8.64s +/- 0.22s / 390 MB RSS