### PR TITLE
feat(render): rasterize pages to PNG via hayro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
 
+      - name: Check without default features
+        run: cargo check --no-default-features --all-targets
+
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +103,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +160,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +196,32 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cbc"
@@ -251,6 +319,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "color"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec7c5eb7a16992b1904d76c517d170ab353b0e0b3d5a0c81a8a0cd1037893cf"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "colorchoice"
@@ -424,10 +501,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "fearless_simd"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97b65636e5b9ef369943878ac74335ba1c55c1cb6adbf1e2c293c624248d693"
 
 [[package]]
 name = "find-msvc-tools"
@@ -452,6 +553,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -491,10 +607,129 @@ dependencies = [
 ]
 
 [[package]]
+name = "glifo"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d99fc21d493812643aae86d53b7bbd02f376434a90317e8a790bc209fdd6605e"
+dependencies = [
+ "bytemuck",
+ "foldhash",
+ "hashbrown",
+ "log",
+ "peniko",
+ "png",
+ "skrifa",
+ "smallvec",
+ "vello_common 0.0.9",
+]
+
+[[package]]
+name = "guillotiere"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b17e70c989c36bad147b27a58d148c0741c51448aa5653436547323e524d0ab"
+dependencies = [
+ "euclid",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hayro"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4caa128ab87fd48ffb7490617cf93f77f606820dffbc9fd9ef6ab0ed077f56d"
+dependencies = [
+ "bytemuck",
+ "hayro-interpret",
+ "image",
+ "kurbo",
+ "pic-scale",
+ "vello_cpu",
+]
+
+[[package]]
+name = "hayro-ccitt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f4d0e94ddd48749f06bbe4e5389fb9799a0c45bcaf00495042076ef05e3241a"
+
+[[package]]
+name = "hayro-cmap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d285dc30731c8485de5fa732fbdf2b3affdf01e4da7c2135022ca6fa664bf6"
+dependencies = [
+ "brotli",
+ "hayro-postscript",
+]
+
+[[package]]
+name = "hayro-interpret"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2613d0406898995042d0794c4245b2f2fba1246490c8ac593769bba6551129d"
+dependencies = [
+ "bitflags 2.13.0",
+ "hayro-cmap",
+ "hayro-syntax",
+ "kurbo",
+ "moxcms",
+ "phf",
+ "rustc-hash",
+ "siphasher",
+ "skrifa",
+ "smallvec",
+ "yoke",
+]
+
+[[package]]
+name = "hayro-jbig2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69374b3668dd45aeb3d3145cda68f2c7b4f223aaa2511e67d076f1c7d741388d"
+dependencies = [
+ "fearless_simd",
+ "hayro-ccitt",
+]
+
+[[package]]
+name = "hayro-jpeg2000"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ab947623ef4ccaa7acf0579edf7cbb5a73838e3839a7be73335e522f433a1"
+dependencies = [
+ "fearless_simd",
+]
+
+[[package]]
+name = "hayro-postscript"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "885c5ef0654933139a9b9546fc2c69e18d37f38aa2520f079092b1be18f1fcaa"
+
+[[package]]
+name = "hayro-syntax"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0edeafd70aa2db743de8ede8637d07ec87db05efe69cde371d03f1b185fcef27"
+dependencies = [
+ "flate2",
+ "hayro-ccitt",
+ "hayro-jbig2",
+ "hayro-jpeg2000",
+ "memchr",
+ "rustc-hash",
+ "smallvec",
+ "zune-jpeg",
+]
 
 [[package]]
 name = "heck"
@@ -533,6 +768,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
 ]
 
 [[package]]
@@ -621,10 +869,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "kurbo"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b60dfc32f652b926df6192e55525b16d186c69d47876c3ead4da5cc9f8450e2"
+dependencies = [
+ "arrayvec",
+ "euclid",
+ "polycool",
+ "smallvec",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -705,6 +971,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,6 +1028,7 @@ version = "0.1.1"
 dependencies = [
  "assert_cmd",
  "clap",
+ "hayro",
  "lopdf",
  "memmap2",
  "predicates",
@@ -761,10 +1038,97 @@ dependencies = [
 ]
 
 [[package]]
+name = "peniko"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "839c8299360d2e998bdb106dc0a6cd71dcc5f4df51df1b620361bf50e283cca6"
+dependencies = [
+ "bytemuck",
+ "color",
+ "kurbo",
+ "linebender_resource_handle",
+ "smallvec",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pic-scale"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b05a62c3762cb26cb62665b915fea652def8a9f609b0b289b7f782a7394307b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polycool"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50596ddc09eb5ad5f75cacd40209568e66df71baf86e1499a0e99c4cff12a5a6"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -849,6 +1213,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,6 +1277,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "read-fonts"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
+dependencies = [
+ "bytemuck",
+ "font-types",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +1314,12 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
@@ -998,10 +1384,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stringprep"
@@ -1029,6 +1443,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1161,6 +1586,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "vello_common"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3361bff7f7d82c0c496b92048db83846691f0e844cc28dee92b1c824291b55ee"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "hashbrown",
+ "log",
+ "peniko",
+ "png",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "vello_common"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
+dependencies = [
+ "bytemuck",
+ "fearless_simd",
+ "guillotiere",
+ "hashbrown",
+ "log",
+ "peniko",
+ "png",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "vello_cpu"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8ded630e8316bb94a55881256506d1f3b9947b5f66db8a7d32ca7ba02decd0"
+dependencies = [
+ "bytemuck",
+ "glifo",
+ "hashbrown",
+ "png",
+ "vello_common 0.0.8",
+]
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,4 +1758,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pdq"
 version = "0.1.1"
 edition = "2021"
-rust-version = "1.88"
+rust-version = "1.92"
 license = "Artistic-2.0"
 description = "PDF operations library"
 repository = "https://github.com/meistrari/pdq"
@@ -10,8 +10,13 @@ readme = "README.md"
 keywords = ["pdf", "split", "merge", "cli"]
 categories = ["command-line-utilities"]
 
+[features]
+default = ["render"]
+render = ["dep:hayro"]
+
 [dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
+hayro = { version = "0.7.1", features = ["embed-fonts"], optional = true }
 lopdf = "0.43.0"
 memmap2 = "0.9.9"
 rayon = "1.12.0"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ of `qpdf --show-npages`).
 Tests may use `qpdf` as a development validator when it is available on `PATH`.
 The runtime implementation must remain qpdf-free.
 
+## Render
+
+`pdq render` rasterizes pages to PNG through [hayro](https://github.com/LaurenzV/hayro),
+a pure-Rust PDF renderer, so the qpdf-free and FFI-free constraints still hold.
+Pages render in parallel and `%d` in the output pattern receives the original,
+zero-padded page number. The command lives behind the `render` cargo feature,
+which is enabled by default; build with `--no-default-features` for a smaller
+split/merge-only binary. Rendering requires Rust 1.92 or newer.
+
 ## Benchmark Snapshot
 
 Measured on 2026-07-03 with local PDFs identified only by page count. Wall time

--- a/src/bin/pdq.rs
+++ b/src/bin/pdq.rs
@@ -20,6 +20,8 @@ enum Command {
     SplitPages(SplitPagesArgs),
     Merge(MergeArgs),
     PageCount(PageCountArgs),
+    #[cfg(feature = "render")]
+    Render(RenderArgs),
 }
 
 #[derive(Debug, Args)]
@@ -52,6 +54,21 @@ struct PageCountArgs {
     input: PathBuf,
 }
 
+#[cfg(feature = "render")]
+#[derive(Debug, Args)]
+struct RenderArgs {
+    input: PathBuf,
+
+    #[arg(short, long, value_name = "PATTERN")]
+    output: String,
+
+    #[arg(long, default_value_t = 150.0)]
+    dpi: f32,
+
+    #[arg(long, value_name = "RANGES")]
+    pages: Option<String>,
+}
+
 fn main() -> ExitCode {
     if let Err(err) = run() {
         eprintln!("error: {err}");
@@ -82,6 +99,14 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         Command::PageCount(args) => {
             let count = page_count(&args.input)?;
             println!("{count}");
+        }
+        #[cfg(feature = "render")]
+        Command::Render(args) => {
+            let options = pdq::RenderOptions {
+                dpi: args.dpi,
+                pages: args.pages.map(PageRangeGroup::parse).transpose()?,
+            };
+            pdq::render_pages(&args.input, &args.output, &options)?;
         }
     }
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ pub mod lazy;
 pub mod load;
 pub mod merge;
 pub mod range;
+#[cfg(feature = "render")]
+pub mod render;
 mod scan;
 pub mod split;
 mod write;
@@ -12,6 +14,8 @@ pub use copy::{CopyContext, CopyOptions};
 pub use count::page_count;
 pub use merge::{merge, merge_with_options, MergeInput, MergeOptions};
 pub use range::{PageRangeError, PageRangeGroup};
+#[cfg(feature = "render")]
+pub use render::{render_pages, RenderOptions};
 pub use split::{split, split_pages, SplitOutput};
 
 pub type Result<T> = std::result::Result<T, PdfOpsError>;

--- a/src/render.rs
+++ b/src/render.rs
@@ -61,7 +61,7 @@ pub fn render_pages(input: &Path, output_pattern: &str, options: &RenderOptions)
         ..Default::default()
     };
 
-    selected.par_iter().try_for_each(|&page_number| {
+    let render_one = |&page_number: &usize| {
         let page = &pages[page_number - 1];
         let (page_width, page_height) = page.render_dimensions();
         if page_width * scale > MAX_PIXMAP_DIMENSION || page_height * scale > MAX_PIXMAP_DIMENSION {
@@ -85,7 +85,12 @@ pub fn render_pages(input: &Path, output_pattern: &str, options: &RenderOptions)
             png,
         )?;
         Ok(())
-    })
+    };
+
+    match rayon::ThreadPoolBuilder::new().build() {
+        Ok(pool) => pool.install(|| selected.par_iter().try_for_each(render_one)),
+        Err(_) => selected.iter().try_for_each(render_one),
+    }
 }
 
 fn load_error(err: LoadPdfError, input: &Path) -> PdfOpsError {

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,102 @@
+use std::{fs, path::Path};
+
+use hayro::{
+    hayro_interpret::InterpreterSettings,
+    hayro_syntax::{LoadPdfError, Pdf},
+    vello_cpu::color::palette::css::WHITE,
+    RenderCache, RenderSettings,
+};
+use rayon::prelude::*;
+
+use crate::{
+    range::{dedupe_preserving_order, PageRangeGroup},
+    split::{render_output_pattern, validate_output_pattern},
+    PdfOpsError, Result,
+};
+
+const POINTS_PER_INCH: f32 = 72.0;
+// hayro pixmaps address pixels with u16 coordinates.
+const MAX_PIXMAP_DIMENSION: f32 = u16::MAX as f32;
+
+#[derive(Debug, Clone)]
+pub struct RenderOptions {
+    pub dpi: f32,
+    pub pages: Option<PageRangeGroup>,
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self {
+            dpi: 150.0,
+            pages: None,
+        }
+    }
+}
+
+pub fn render_pages(input: &Path, output_pattern: &str, options: &RenderOptions) -> Result<()> {
+    validate_output_pattern(output_pattern)?;
+    if !options.dpi.is_finite() || options.dpi <= 0.0 {
+        return Err(PdfOpsError::InvalidStructure(format!(
+            "render dpi must be a positive number, got {}",
+            options.dpi
+        )));
+    }
+    let scale = options.dpi / POINTS_PER_INCH;
+
+    let data = fs::read(input)?;
+    let pdf = Pdf::new(data).map_err(|err| load_error(err, input))?;
+    let pages = pdf.pages();
+
+    let selected = match &options.pages {
+        Some(range) => dedupe_preserving_order(&range.resolve(pages.len())?),
+        None => (1..=pages.len()).collect(),
+    };
+    let width = pages.len().to_string().len();
+
+    let interpreter_settings = InterpreterSettings::default();
+    let render_settings = RenderSettings {
+        x_scale: scale,
+        y_scale: scale,
+        bg_color: WHITE,
+        ..Default::default()
+    };
+
+    selected.par_iter().try_for_each(|&page_number| {
+        let page = &pages[page_number - 1];
+        let (page_width, page_height) = page.render_dimensions();
+        if page_width * scale > MAX_PIXMAP_DIMENSION || page_height * scale > MAX_PIXMAP_DIMENSION {
+            return Err(PdfOpsError::Unsupported(format!(
+                "page {page_number} is too large to render at {} dpi",
+                options.dpi
+            )));
+        }
+
+        // RenderCache is Rc-based and cannot cross threads; it only shares
+        // work across pages, so a per-page cache costs almost nothing.
+        let cache = RenderCache::new();
+        let pixmap = hayro::render(page, &cache, &interpreter_settings, &render_settings);
+        let png = pixmap.into_png().map_err(|err| {
+            PdfOpsError::InvalidStructure(format!(
+                "failed to encode page {page_number} as PNG: {err}"
+            ))
+        })?;
+        fs::write(
+            render_output_pattern(output_pattern, page_number, width)?,
+            png,
+        )?;
+        Ok(())
+    })
+}
+
+fn load_error(err: LoadPdfError, input: &Path) -> PdfOpsError {
+    match err {
+        LoadPdfError::Decryption(_) => PdfOpsError::Unsupported(format!(
+            "encrypted PDFs are not supported: {}",
+            input.display()
+        )),
+        LoadPdfError::Invalid => PdfOpsError::InvalidStructure(format!(
+            "failed to parse PDF for rendering: {}",
+            input.display()
+        )),
+    }
+}

--- a/src/split.rs
+++ b/src/split.rs
@@ -115,7 +115,7 @@ pub(crate) fn validate_output_pattern(pattern: &str) -> Result<()> {
     let occurrences = pattern.match_indices("%d").count();
     if occurrences != 1 {
         return Err(PdfOpsError::InvalidStructure(
-            "split-pages output pattern must contain exactly one %d".into(),
+            "output pattern must contain exactly one %d".into(),
         ));
     }
     Ok(())

--- a/src/split.rs
+++ b/src/split.rs
@@ -102,12 +102,16 @@ fn reject_duplicate_output_paths(outputs: &[ResolvedSplitOutput]) -> Result<()> 
     Ok(())
 }
 
-fn render_output_pattern(pattern: &str, page_number: usize, width: usize) -> Result<PathBuf> {
+pub(crate) fn render_output_pattern(
+    pattern: &str,
+    page_number: usize,
+    width: usize,
+) -> Result<PathBuf> {
     let page = format!("{page_number:0width$}");
     Ok(PathBuf::from(pattern.replacen("%d", &page, 1)))
 }
 
-fn validate_output_pattern(pattern: &str) -> Result<()> {
+pub(crate) fn validate_output_pattern(pattern: &str) -> Result<()> {
     let occurrences = pattern.match_indices("%d").count();
     if occurrences != 1 {
         return Err(PdfOpsError::InvalidStructure(

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -137,7 +137,10 @@ fn render_rejects_encrypted_inputs_with_unsupported_error() {
     .unwrap_err();
 
     assert!(matches!(error, PdfOpsError::Unsupported(_)));
-    assert!(!temp.path().join("enc-1.png").exists());
+    assert!(
+        std::fs::read_dir(temp.path()).unwrap().next().is_none(),
+        "no output should be written for encrypted input"
+    );
 }
 
 #[test]

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -1,0 +1,212 @@
+#![cfg(feature = "render")]
+
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use pdq::{render_pages, PageRangeGroup, PdfOpsError, RenderOptions};
+use predicates::prelude::*;
+use tempfile::tempdir;
+
+const PNG_MAGIC: [u8; 8] = [0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n'];
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn png_dimensions(path: &Path) -> (u32, u32) {
+    let bytes = std::fs::read(path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+    assert_eq!(bytes[..8], PNG_MAGIC, "{} is not a PNG", path.display());
+    let width = u32::from_be_bytes(bytes[16..20].try_into().unwrap());
+    let height = u32::from_be_bytes(bytes[20..24].try_into().unwrap());
+    (width, height)
+}
+
+#[test]
+fn render_writes_png_for_each_page() {
+    let temp = tempdir().unwrap();
+    let pattern = temp.path().join("page-%d.png");
+
+    render_pages(
+        &fixture("11-pages.pdf"),
+        pattern.to_str().unwrap(),
+        &RenderOptions {
+            dpi: 72.0,
+            pages: None,
+        },
+    )
+    .unwrap();
+
+    for page in 1..=11 {
+        let path = temp.path().join(format!("page-{page:02}.png"));
+        let (width, height) = png_dimensions(&path);
+        assert!(
+            width > 0 && height > 0,
+            "empty render for {}",
+            path.display()
+        );
+    }
+}
+
+#[test]
+fn render_scales_dimensions_with_dpi() {
+    let temp = tempdir().unwrap();
+    let pattern = temp.path().join("dpi-%d.png");
+
+    render_pages(
+        &fixture("11-pages.pdf"),
+        pattern.to_str().unwrap(),
+        &RenderOptions {
+            dpi: 144.0,
+            pages: Some(PageRangeGroup::parse("1").unwrap()),
+        },
+    )
+    .unwrap();
+
+    let (width_144, height_144) = png_dimensions(&temp.path().join("dpi-01.png"));
+
+    let pattern = temp.path().join("base-%d.png");
+    render_pages(
+        &fixture("11-pages.pdf"),
+        pattern.to_str().unwrap(),
+        &RenderOptions {
+            dpi: 72.0,
+            pages: Some(PageRangeGroup::parse("1").unwrap()),
+        },
+    )
+    .unwrap();
+
+    let (width_72, height_72) = png_dimensions(&temp.path().join("base-01.png"));
+    assert_eq!(width_144, width_72 * 2);
+    assert_eq!(height_144, height_72 * 2);
+}
+
+#[test]
+fn render_selected_pages_keeps_original_numbering() {
+    let temp = tempdir().unwrap();
+    let pattern = temp.path().join("sel-%d.png");
+
+    render_pages(
+        &fixture("11-pages.pdf"),
+        pattern.to_str().unwrap(),
+        &RenderOptions {
+            dpi: 72.0,
+            pages: Some(PageRangeGroup::parse("2,11").unwrap()),
+        },
+    )
+    .unwrap();
+
+    assert!(temp.path().join("sel-02.png").exists());
+    assert!(temp.path().join("sel-11.png").exists());
+    assert!(!temp.path().join("sel-01.png").exists());
+    assert!(!temp.path().join("sel-03.png").exists());
+}
+
+#[test]
+fn render_rejects_out_of_bounds_pages() {
+    let temp = tempdir().unwrap();
+    let pattern = temp.path().join("oob-%d.png");
+
+    let error = render_pages(
+        &fixture("11-pages.pdf"),
+        pattern.to_str().unwrap(),
+        &RenderOptions {
+            dpi: 72.0,
+            pages: Some(PageRangeGroup::parse("12").unwrap()),
+        },
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, PdfOpsError::Range(_)));
+    assert!(!temp.path().join("oob-12.png").exists());
+}
+
+#[test]
+fn render_rejects_encrypted_inputs_with_unsupported_error() {
+    let temp = tempdir().unwrap();
+    let pattern = temp.path().join("enc-%d.png");
+
+    let error = render_pages(
+        &fixture("user-password.pdf"),
+        pattern.to_str().unwrap(),
+        &RenderOptions::default(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, PdfOpsError::Unsupported(_)));
+    assert!(!temp.path().join("enc-1.png").exists());
+}
+
+#[test]
+fn render_rejects_pattern_without_placeholder() {
+    let temp = tempdir().unwrap();
+
+    let error = render_pages(
+        &fixture("11-pages.pdf"),
+        temp.path().join("page.png").to_str().unwrap(),
+        &RenderOptions::default(),
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, PdfOpsError::InvalidStructure(_)));
+}
+
+#[test]
+fn render_rejects_nonpositive_dpi() {
+    let temp = tempdir().unwrap();
+    let pattern = temp.path().join("bad-%d.png");
+
+    let error = render_pages(
+        &fixture("11-pages.pdf"),
+        pattern.to_str().unwrap(),
+        &RenderOptions {
+            dpi: 0.0,
+            pages: None,
+        },
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, PdfOpsError::InvalidStructure(_)));
+}
+
+#[test]
+fn render_cli_writes_selected_page() {
+    let temp = tempdir().unwrap();
+    let pattern = temp.path().join("cli-%d.png");
+
+    Command::cargo_bin("pdq")
+        .unwrap()
+        .arg("render")
+        .arg(fixture("11-pages.pdf"))
+        .arg("--output")
+        .arg(&pattern)
+        .arg("--dpi")
+        .arg("72")
+        .arg("--pages")
+        .arg("3")
+        .assert()
+        .success();
+
+    let (width, height) = png_dimensions(&temp.path().join("cli-03.png"));
+    assert!(width > 0 && height > 0);
+}
+
+#[test]
+fn render_cli_rejects_invalid_pages_range() {
+    let temp = tempdir().unwrap();
+
+    Command::cargo_bin("pdq")
+        .unwrap()
+        .arg("render")
+        .arg(fixture("11-pages.pdf"))
+        .arg("--output")
+        .arg(temp.path().join("bad-%d.png"))
+        .arg("--pages")
+        .arg("abc")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid page number"));
+}


### PR DESCRIPTION
## What

New `pdq render` subcommand and `render_pages` library API that rasterize PDF pages to PNG:

```sh
pdq render input.pdf --output 'page-%d.png' --dpi 150 --pages 1-3,r1
```

## Design

- **Renderer**: [hayro](https://github.com/LaurenzV/hayro) 0.7.1 (pure Rust, MIT/Apache-2.0, `forbid(unsafe)`), so the repo's qpdf-free / FFI-free constraints still hold. The `embed-fonts` feature covers PDFs relying on the standard-14 fonts.
- **Feature flag**: `render` is a default-on cargo feature; `--no-default-features` still builds the slim split/merge binary and CI now checks that configuration.
- **Parallelism**: one rayon task per page (`Page` is `Sync`; `RenderCache` is `Rc`-based, so each page builds its own).
- **Semantics**: `%d` receives the original zero-padded page number (`--pages 2,11` writes `page-02.png` and `page-11.png`); page selection reuses `PageRangeGroup`; encrypted inputs map to the same `Unsupported` error as split/merge.
- **MSRV**: 1.88 → 1.92, required by hayro.

## Spike numbers (M-series laptop, 150 dpi, 2200-page PDF)

| Tool | Wall time | Throughput |
| --- | ---: | ---: |
| pdq render (parallel) | 1.9s | 1173 pages/s |
| pdq render (sequential) | 22.4s | 98 pages/s |
| mutool draw | 28.7s | 77 pages/s |
| pdftoppm | 77s | 29 pages/s |

Rendering quality was verified visually against a real-world arXiv paper (vector figures, LaTeX math, embedded fonts) and the repo fixtures (non-embedded standard fonts).

## Testing

- 9 new integration tests in `tests/render.rs`: per-page output, dpi scaling, page selection and numbering, out-of-bounds ranges, encrypted input, pattern validation, non-positive dpi, CLI happy path and CLI error surface.
- Full suite: 63 tests passing locally with Rust 1.92; `cargo check --no-default-features --all-targets` clean; clippy and rustfmt clean.