### PR TITLE
feat(pdq): add --pages-per-file chunking to split-pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,14 @@ out of scope for the current MVP.
 cargo test
 cargo run --bin pdq -- split input.pdf --out 1-3 out-1.pdf --out 4-z out-2.pdf
 cargo run --bin pdq -- split-pages --output 'page-%d.pdf' input.pdf
+cargo run --bin pdq -- split-pages --output 'chunk-%d.pdf' --pages-per-file 3 input.pdf
 cargo run --bin pdq -- merge --output merged.pdf a.pdf b.pdf
 cargo run --bin pdq -- page-count input.pdf
 ```
+
+`split-pages --pages-per-file N` groups consecutive pages into files of at most
+N pages each (`%d` is the 1-based chunk index; the last chunk may contain fewer
+pages). The default of 1 writes one page per file.
 
 `page-count` prints the number of pages to stdout (the `lopdf`-native equivalent
 of `qpdf --show-npages`).

--- a/src/bin/pdq.rs
+++ b/src/bin/pdq.rs
@@ -2,8 +2,8 @@ use std::{path::PathBuf, process::ExitCode};
 
 use clap::{Args, Parser, Subcommand};
 use pdq::{
-    merge_with_options, page_count, split, split_pages, MergeInput, MergeOptions, PageRangeGroup,
-    SplitOutput,
+    merge_with_options, page_count, split, split_pages_with_options, MergeInput, MergeOptions,
+    PageRangeGroup, SplitOutput, SplitPagesOptions,
 };
 
 #[derive(Debug, Parser)]
@@ -47,6 +47,15 @@ struct SplitPagesArgs {
 
     #[arg(short, long, value_name = "PATTERN")]
     output: String,
+
+    /// Maximum number of pages per output file (%d becomes the chunk index)
+    #[arg(
+        long,
+        value_name = "N",
+        default_value_t = 1,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    pages_per_file: u64,
 }
 
 #[derive(Debug, Args)]
@@ -84,7 +93,13 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             split(&args.input, &outputs)?;
         }
         Command::SplitPages(args) => {
-            split_pages(&args.input, &args.output)?;
+            split_pages_with_options(
+                &args.input,
+                &args.output,
+                &SplitPagesOptions {
+                    pages_per_file: args.pages_per_file as usize,
+                },
+            )?;
         }
         Command::Merge(args) => {
             let inputs = parse_merge_inputs(args.inputs);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use merge::{merge, merge_with_options, MergeInput, MergeOptions};
 pub use range::{PageRangeError, PageRangeGroup};
 #[cfg(feature = "render")]
 pub use render::{render_pages, RenderOptions};
-pub use split::{split, split_pages, SplitOutput};
+pub use split::{split, split_pages, split_pages_with_options, SplitOutput, SplitPagesOptions};
 
 pub type Result<T> = std::result::Result<T, PdfOpsError>;
 

--- a/src/split.rs
+++ b/src/split.rs
@@ -39,8 +39,33 @@ pub fn split(input: &Path, outputs: &[SplitOutput]) -> Result<()> {
     run_split_outputs(&source, &resolved_outputs)
 }
 
+#[derive(Debug, Clone)]
+pub struct SplitPagesOptions {
+    /// Maximum number of consecutive pages written to each output file.
+    pub pages_per_file: usize,
+}
+
+impl Default for SplitPagesOptions {
+    fn default() -> Self {
+        Self { pages_per_file: 1 }
+    }
+}
+
 pub fn split_pages(input: &Path, output_pattern: &str) -> Result<()> {
+    split_pages_with_options(input, output_pattern, &SplitPagesOptions::default())
+}
+
+pub fn split_pages_with_options(
+    input: &Path,
+    output_pattern: &str,
+    options: &SplitPagesOptions,
+) -> Result<()> {
     validate_output_pattern(output_pattern)?;
+    if options.pages_per_file == 0 {
+        return Err(PdfOpsError::InvalidStructure(
+            "pages-per-file must be at least 1".into(),
+        ));
+    }
 
     let mmap = map_file(input)?;
     let source = LazyPdf::parse(&mmap, input)?;
@@ -49,13 +74,15 @@ pub fn split_pages(input: &Path, output_pattern: &str) -> Result<()> {
     if page_count == 0 {
         return Err(PdfOpsError::Range(PageRangeError::NoPages));
     }
-    let width = page_count.to_string().len();
-    let resolved_outputs = (1..=page_count)
-        .zip(pages)
-        .map(|(page_number, page_id)| {
+    let chunk_count = page_count.div_ceil(options.pages_per_file);
+    let width = chunk_count.to_string().len();
+    let resolved_outputs = pages
+        .chunks(options.pages_per_file)
+        .enumerate()
+        .map(|(chunk_index, chunk)| {
             Ok(ResolvedSplitOutput {
-                path: render_output_pattern(output_pattern, page_number, width)?,
-                page_ids: vec![page_id],
+                path: render_output_pattern(output_pattern, chunk_index + 1, width)?,
+                page_ids: chunk.to_vec(),
             })
         })
         .collect::<Result<Vec<_>>>()?;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -208,6 +208,44 @@ fn split_pages_cli_rejects_pattern_with_multiple_placeholders() {
 }
 
 #[test]
+fn split_pages_cli_chunks_pages_per_file() {
+    let temp = tempdir().unwrap();
+
+    pdq()
+        .arg("split-pages")
+        .arg(fixture("11-pages.pdf"))
+        .arg("--output")
+        .arg(temp.path().join("chunk-%d.pdf"))
+        .arg("--pages-per-file")
+        .arg("4")
+        .assert()
+        .success();
+
+    assert_page_count(&temp.path().join("chunk-1.pdf"), 4);
+    assert_page_count(&temp.path().join("chunk-2.pdf"), 4);
+    assert_page_count(&temp.path().join("chunk-3.pdf"), 3);
+    assert!(!temp.path().join("chunk-4.pdf").exists());
+}
+
+#[test]
+fn split_pages_cli_rejects_zero_pages_per_file() {
+    let temp = tempdir().unwrap();
+
+    pdq()
+        .arg("split-pages")
+        .arg(fixture("11-pages.pdf"))
+        .arg("--output")
+        .arg(temp.path().join("chunk-%d.pdf"))
+        .arg("--pages-per-file")
+        .arg("0")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("pages-per-file"));
+
+    assert!(!temp.path().join("chunk-1.pdf").exists());
+}
+
+#[test]
 fn cli_without_subcommand_prints_usage() {
     pdq()
         .assert()

--- a/tests/split_merge.rs
+++ b/tests/split_merge.rs
@@ -6,8 +6,8 @@ use std::{
 
 use lopdf::{dictionary, Dictionary, Document, Object, Stream};
 use pdq::{
-    merge, merge_with_options, page_count, split, split_pages, MergeInput, MergeOptions,
-    PageRangeGroup, PdfOpsError, SplitOutput,
+    merge, merge_with_options, page_count, split, split_pages, split_pages_with_options,
+    MergeInput, MergeOptions, PageRangeGroup, PdfOpsError, SplitOutput, SplitPagesOptions,
 };
 use tempfile::tempdir;
 
@@ -345,6 +345,100 @@ fn split_pages_cli_writes_one_output_per_page() {
 }
 
 #[test]
+fn split_pages_with_options_chunks_pages_and_qpdf_validates_page_counts() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("five-pages.pdf");
+    let pattern = temp.path().join("chunk-%d.pdf");
+
+    write_simple_pdf(&input, 5);
+    split_pages_with_options(
+        &input,
+        pattern.to_str().unwrap(),
+        &SplitPagesOptions { pages_per_file: 2 },
+    )
+    .unwrap();
+
+    let qpdf = QpdfValidator::detect();
+    for (chunk, expected_pages) in [(1, 2), (2, 2), (3, 1)] {
+        let path = temp.path().join(format!("chunk-{chunk}.pdf"));
+        assert_written(&path);
+        qpdf.validate(&path, expected_pages);
+    }
+    assert!(!temp.path().join("chunk-4.pdf").exists());
+}
+
+#[test]
+fn split_pages_with_options_larger_than_page_count_writes_single_output() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("five-pages.pdf");
+    let pattern = temp.path().join("all-%d.pdf");
+
+    write_simple_pdf(&input, 5);
+    split_pages_with_options(
+        &input,
+        pattern.to_str().unwrap(),
+        &SplitPagesOptions { pages_per_file: 9 },
+    )
+    .unwrap();
+
+    let output = temp.path().join("all-1.pdf");
+    assert_written(&output);
+    QpdfValidator::detect().validate(&output, 5);
+    assert!(!temp.path().join("all-2.pdf").exists());
+}
+
+#[test]
+fn split_pages_with_options_rejects_zero_pages_per_file() {
+    let temp = tempdir().unwrap();
+    let pattern = temp.path().join("should-not-exist-%d.pdf");
+
+    let error = split_pages_with_options(
+        &fixture("11-pages.pdf"),
+        pattern.to_str().unwrap(),
+        &SplitPagesOptions { pages_per_file: 0 },
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, PdfOpsError::InvalidStructure(_)));
+    assert!(!temp.path().join("should-not-exist-1.pdf").exists());
+}
+
+#[test]
+fn split_pages_with_options_pads_numbers_to_chunk_count_width() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("twelve-pages.pdf");
+
+    write_simple_pdf(&input, 12);
+
+    let per_page_pattern = temp.path().join("page-%d.pdf");
+    split_pages_with_options(
+        &input,
+        per_page_pattern.to_str().unwrap(),
+        &SplitPagesOptions { pages_per_file: 1 },
+    )
+    .unwrap();
+    for page in 1..=12 {
+        assert_written(&temp.path().join(format!("page-{page:02}.pdf")));
+    }
+
+    let chunk_pattern = temp.path().join("chunk-%d.pdf");
+    split_pages_with_options(
+        &input,
+        chunk_pattern.to_str().unwrap(),
+        &SplitPagesOptions { pages_per_file: 5 },
+    )
+    .unwrap();
+
+    let qpdf = QpdfValidator::detect();
+    for (chunk, expected_pages) in [(1, 5), (2, 5), (3, 2)] {
+        let path = temp.path().join(format!("chunk-{chunk}.pdf"));
+        assert_written(&path);
+        qpdf.validate(&path, expected_pages);
+    }
+    assert!(!temp.path().join("chunk-4.pdf").exists());
+}
+
+#[test]
 fn split_pages_writes_object_stream_input() {
     let temp = tempdir().unwrap();
     let pattern = temp.path().join("obj-page-%d.pdf");
@@ -570,6 +664,51 @@ fn split_rejects_duplicate_output_paths_before_writing() {
 
     assert!(matches!(error, PdfOpsError::InvalidStructure(_)));
     assert!(!duplicate.exists());
+}
+
+fn write_simple_pdf(path: &Path, page_count: usize) {
+    let mut document = Document::with_version("1.7");
+    let catalog_id = document.new_object_id();
+    let pages_id = document.new_object_id();
+
+    let kids = (0..page_count)
+        .map(|_| {
+            let content_id = document.add_object(Object::Stream(Stream::new(
+                Dictionary::new(),
+                b"q Q".to_vec(),
+            )));
+            let page_id = document.add_object(dictionary! {
+                "Type" => "Page",
+                "Parent" => pages_id,
+                "MediaBox" => Object::Array(vec![0.into(), 0.into(), 100.into(), 100.into()]),
+                "Resources" => dictionary! {},
+                "Contents" => content_id,
+            });
+            Object::Reference(page_id)
+        })
+        .collect::<Vec<_>>();
+
+    document.objects.insert(
+        pages_id,
+        dictionary! {
+            "Type" => "Pages",
+            "Kids" => Object::Array(kids),
+            "Count" => page_count as i64,
+        }
+        .into(),
+    );
+    document.objects.insert(
+        catalog_id,
+        dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        }
+        .into(),
+    );
+    document.trailer.set("Root", catalog_id);
+    document
+        .save(path)
+        .unwrap_or_else(|err| panic!("failed to save simple fixture: {err}"));
 }
 
 fn write_one_page_pdf_with_dangling_reference(path: &Path) {


### PR DESCRIPTION
## What

Adds chunked splitting to `split-pages` — the pdq equivalent of qpdf's `--split-pages=n`:

```sh
pdq split-pages --output 'chunk-%d.pdf' --pages-per-file 3 input.pdf
```

## Semantics

- Pages are grouped into consecutive chunks of at most N pages; the last chunk may contain fewer.
- `%d` in the output pattern is the 1-based chunk index, zero-padded to the digit width of the chunk count (so the default N=1 produces byte-identical names and behavior to today).
- `--pages-per-file 0` is rejected by clap (`range(1..)`), and `split_pages_with_options` also validates it library-side with an `InvalidStructure` error.

## Library API

- New `SplitPagesOptions { pages_per_file: usize }` with `Default` (1) and `split_pages_with_options(input, output_pattern, &options)`, both re-exported from the crate root.
- `split_pages` is unchanged in signature and behavior; it now delegates to the options variant with defaults.

## Tests

- Library: 5-page PDF with N=2 → 3 files (2, 2, 1 pages); N > page count → single output; N=0 errors without writing; zero-padding (12 pages N=1 → `page-01.pdf`..`page-12.pdf`, N=5 → `chunk-1.pdf`..`chunk-3.pdf` with 5, 5, 2 pages). Outputs are validated with qpdf (`--check` + `--show-npages`) when available, following the existing `QpdfValidator::detect()` pattern.
- CLI: `--pages-per-file 4` on the 11-page fixture → 3 files (4, 4, 3 pages); `--pages-per-file 0` fails with non-zero exit.
- All existing tests pass untouched; `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.