### PR TITLE
feat(pdq): decrypt encrypted PDFs on load with optional --password

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,19 @@ Runtime constraints:
 - does not link libqpdf through FFI.
 
 The first implementation uses `lopdf` as a pure-Rust PDF object model and
-writer. It focuses on valid split/merge outputs for ordinary, unencrypted PDFs.
-Advanced qpdf behavior such as repair, encryption, linearization, forms,
-outlines, and full compatibility with unusual historical PDFs is intentionally
-out of scope for the current MVP.
+writer. It focuses on valid split/merge outputs for ordinary PDFs. Advanced
+qpdf behavior such as repair, linearization, forms, outlines, and full
+compatibility with unusual historical PDFs is intentionally out of scope for
+the current MVP.
+
+Encrypted PDFs (RC4, AES-128, AES-256) are supported as inputs: files are
+decrypted while loading, and outputs are always written unencrypted (like
+`qpdf --decrypt`). Files encrypted with only an owner password — the common
+case — open without any flags because the empty user password is tried first.
+Files that require a real password take `--password` on `split`,
+`split-pages`, `merge`, and `page-count`. `render` goes through hayro's own
+parser, which likewise opens owner-password-only files but has no
+`--password` option, so PDFs with a real user password cannot be rendered.
 
 ## Commands
 
@@ -23,6 +32,7 @@ cargo run --bin pdq -- split-pages --output 'page-%d.pdf' input.pdf
 cargo run --bin pdq -- split-pages --output 'chunk-%d.pdf' --pages-per-file 3 input.pdf
 cargo run --bin pdq -- merge --output merged.pdf a.pdf b.pdf
 cargo run --bin pdq -- page-count input.pdf
+cargo run --bin pdq -- split-pages --password secret --output 'page-%d.pdf' encrypted.pdf
 ```
 
 `split-pages --pages-per-file N` groups consecutive pages into files of at most
@@ -31,6 +41,9 @@ pages). The default of 1 writes one page per file.
 
 `page-count` prints the number of pages to stdout (the `lopdf`-native equivalent
 of `qpdf --show-npages`).
+
+`--password` decrypts inputs that need a user or owner password; the outputs
+of `split`, `split-pages`, and `merge` are written decrypted either way.
 
 Tests may use `qpdf` as a development validator when it is available on `PATH`.
 The runtime implementation must remain qpdf-free.

--- a/src/bin/pdq.rs
+++ b/src/bin/pdq.rs
@@ -2,8 +2,8 @@ use std::{path::PathBuf, process::ExitCode};
 
 use clap::{Args, Parser, Subcommand};
 use pdq::{
-    merge_with_options, page_count, split, split_pages_with_options, MergeInput, MergeOptions,
-    PageRangeGroup, SplitOutput, SplitPagesOptions,
+    merge_with_options, page_count_with_password, split_pages_with_options, split_with_password,
+    MergeInput, MergeOptions, PageRangeGroup, SplitOutput, SplitPagesOptions,
 };
 
 #[derive(Debug, Parser)]
@@ -30,6 +30,10 @@ struct SplitArgs {
 
     #[arg(long = "out", required = true, value_names = ["RANGE", "PATH"], num_args = 2)]
     outputs: Vec<String>,
+
+    /// Password for encrypted inputs; outputs are always written decrypted
+    #[arg(long, value_name = "PASSWORD")]
+    password: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -39,6 +43,10 @@ struct MergeArgs {
 
     #[arg(required = true)]
     inputs: Vec<PathBuf>,
+
+    /// Password for encrypted inputs; outputs are always written decrypted
+    #[arg(long, value_name = "PASSWORD")]
+    password: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -56,11 +64,19 @@ struct SplitPagesArgs {
         value_parser = clap::value_parser!(u64).range(1..)
     )]
     pages_per_file: u64,
+
+    /// Password for encrypted inputs; outputs are always written decrypted
+    #[arg(long, value_name = "PASSWORD")]
+    password: Option<String>,
 }
 
 #[derive(Debug, Args)]
 struct PageCountArgs {
     input: PathBuf,
+
+    /// Password for encrypted inputs
+    #[arg(long, value_name = "PASSWORD")]
+    password: Option<String>,
 }
 
 #[cfg(feature = "render")]
@@ -90,7 +106,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     match Cli::parse().command {
         Command::Split(args) => {
             let outputs = parse_split_outputs(args.outputs)?;
-            split(&args.input, &outputs)?;
+            split_with_password(&args.input, &outputs, args.password.as_deref())?;
         }
         Command::SplitPages(args) => {
             split_pages_with_options(
@@ -98,6 +114,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 &args.output,
                 &SplitPagesOptions {
                     pages_per_file: args.pages_per_file as usize,
+                    password: args.password,
                 },
             )?;
         }
@@ -108,11 +125,12 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 &args.output,
                 MergeOptions {
                     preserve_whole_single_input: true,
+                    password: args.password,
                 },
             )?;
         }
         Command::PageCount(args) => {
-            let count = page_count(&args.input)?;
+            let count = page_count_with_password(&args.input, args.password.as_deref())?;
             println!("{count}");
         }
         #[cfg(feature = "render")]

--- a/src/count.rs
+++ b/src/count.rs
@@ -1,18 +1,25 @@
 use std::path::Path;
 
-use crate::{lazy::LazyPdf, load::map_file, Result};
+use crate::{lazy::PdfSource, load::map_file, Result};
 
 /// Count the pages in a PDF.
 ///
 /// Uses the same lazy, mmap-backed reader as `split-pages` and counts via the
 /// shared page-tree walk (`count_pages`), so it stays cheap on very large
 /// documents — O(1) memory, no per-page id allocation — and can never disagree
-/// with the pages `split`/`split-pages` would resolve. Encrypted PDFs are
-/// rejected, consistent with the rest of the MVP.
+/// with the pages `split`/`split-pages` would resolve. Encrypted PDFs with an
+/// empty user password are decrypted transparently; files that need a real
+/// password require [`page_count_with_password`].
 ///
 /// Returns `0` for a structurally valid PDF that declares no pages.
 pub fn page_count(input: &Path) -> Result<usize> {
+    page_count_with_password(input, None)
+}
+
+/// Like [`page_count`], additionally decrypting encrypted inputs with
+/// `password` when the empty user password does not authenticate.
+pub fn page_count_with_password(input: &Path, password: Option<&str>) -> Result<usize> {
     let mmap = map_file(input)?;
-    let source = LazyPdf::parse(&mmap, input)?;
+    let source = PdfSource::open(&mmap, input, password)?;
     source.count_pages()
 }

--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -5,11 +5,83 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use lopdf::{xref::XrefEntry, Document, LoadOptions, Object, ObjectId, ObjectStream, Reader};
+use lopdf::{xref::XrefEntry, Document, Object, ObjectId, ObjectStream, Reader};
 
-use crate::{copy::ObjectSource, PdfOpsError, Result};
+use crate::{
+    copy::ObjectSource,
+    load::{decorate_load_error, ensure_decrypted, load_options},
+    PdfOpsError, Result,
+};
 
 const OBJECT_STREAM_CACHE_LIMIT: usize = 512;
+
+/// A parsed PDF input: lazily backed by the mmap for plain files, eagerly
+/// loaded for encrypted files.
+///
+/// Unencrypted inputs keep the metadata-only lazy reader — the fast path that
+/// parses objects on demand straight from the buffer. Encrypted inputs cannot
+/// use it: the lazy reader would hand out still-encrypted bytes. lopdf also
+/// ignores the metadata filter for encrypted PDFs and materializes every
+/// object while decrypting during the load, so by the time we know the input
+/// was encrypted we already hold a fully decrypted document — using it
+/// eagerly costs nothing extra.
+//
+// One PdfSource exists per input file and it is only handled by reference,
+// so the enum's size is irrelevant; boxing a variant would just add an
+// indirection to every object lookup on the lazy hot path.
+#[allow(clippy::large_enum_variant)]
+pub(crate) enum PdfSource<'a> {
+    Lazy(LazyPdf<'a>),
+    Eager(Document),
+}
+
+impl<'a> PdfSource<'a> {
+    /// Parse `buffer`, transparently decrypting encrypted inputs. The empty
+    /// user password is always tried first, then `password` when provided.
+    pub(crate) fn open(buffer: &'a [u8], path: &Path, password: Option<&str>) -> Result<Self> {
+        let document =
+            Document::load_mem_with_options(buffer, load_options(password, Some(drop_object)))
+                .map_err(|err| decorate_load_error(err, path))?;
+        ensure_decrypted(&document, path)?;
+        if document.was_encrypted() {
+            return Ok(Self::Eager(document));
+        }
+        Ok(Self::Lazy(LazyPdf::new(buffer, document)?))
+    }
+
+    pub(crate) fn page_ids(&self) -> Result<Vec<ObjectId>> {
+        match self {
+            Self::Lazy(lazy) => lazy.page_ids(),
+            Self::Eager(document) => Ok(document.page_iter().collect()),
+        }
+    }
+
+    pub(crate) fn count_pages(&self) -> Result<usize> {
+        match self {
+            Self::Lazy(lazy) => lazy.count_pages(),
+            Self::Eager(document) => Ok(document.page_iter().count()),
+        }
+    }
+
+    /// True when the input was encrypted and decrypted during the load. Such
+    /// inputs must be rewritten — never byte-copied — so that outputs are
+    /// always unencrypted.
+    pub(crate) fn was_encrypted(&self) -> bool {
+        match self {
+            Self::Lazy(_) => false,
+            Self::Eager(document) => document.was_encrypted(),
+        }
+    }
+}
+
+impl ObjectSource for PdfSource<'_> {
+    fn get_object_value(&self, id: ObjectId) -> std::result::Result<Cow<'_, Object>, lopdf::Error> {
+        match self {
+            Self::Lazy(lazy) => lazy.get_object_value(id),
+            Self::Eager(document) => document.get_object_value(id),
+        }
+    }
+}
 
 pub(crate) struct LazyPdf<'a> {
     reader: Reader<'a>,
@@ -17,16 +89,9 @@ pub(crate) struct LazyPdf<'a> {
 }
 
 impl<'a> LazyPdf<'a> {
-    pub(crate) fn parse(buffer: &'a [u8], path: &Path) -> Result<Self> {
-        let document =
-            Document::load_mem_with_options(buffer, LoadOptions::with_filter(drop_object))?;
-        if document.is_encrypted() || document.was_encrypted() {
-            return Err(PdfOpsError::Unsupported(format!(
-                "encrypted PDFs are not supported: {}",
-                path.display()
-            )));
-        }
-
+    /// Build the lazy reader from a metadata-only `Document` (trailer and
+    /// xref, no objects) previously loaded from `buffer`.
+    fn new(buffer: &'a [u8], document: Document) -> Result<Self> {
         let reader = Reader {
             buffer,
             document,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,15 @@ pub mod split;
 mod write;
 
 pub use copy::{CopyContext, CopyOptions};
-pub use count::page_count;
+pub use count::{page_count, page_count_with_password};
 pub use merge::{merge, merge_with_options, MergeInput, MergeOptions};
 pub use range::{PageRangeError, PageRangeGroup};
 #[cfg(feature = "render")]
 pub use render::{render_pages, RenderOptions};
-pub use split::{split, split_pages, split_pages_with_options, SplitOutput, SplitPagesOptions};
+pub use split::{
+    split, split_pages, split_pages_with_options, split_pages_with_password, split_with_password,
+    SplitOutput, SplitPagesOptions,
+};
 
 pub type Result<T> = std::result::Result<T, PdfOpsError>;
 
@@ -33,6 +36,11 @@ pub enum PdfOpsError {
 
     #[error("unsupported PDF feature: {0}")]
     Unsupported(String),
+
+    /// An encrypted input could not be decrypted: either it requires a
+    /// password that was not supplied, or the supplied password is wrong.
+    #[error("{0}")]
+    Password(String),
 
     #[error("invalid PDF structure: {0}")]
     InvalidStructure(String),

--- a/src/load.rs
+++ b/src/load.rs
@@ -1,30 +1,58 @@
 use std::{fs::File, path::Path};
 
-use lopdf::{Document, LoadOptions};
+use lopdf::{Document, FilterFunc, LoadOptions};
 use memmap2::{Mmap, MmapOptions};
 
 use crate::{range::PageRangeError, PdfOpsError, Result};
 
-pub(crate) fn load_document(path: &Path) -> Result<Document> {
-    let document = load_document_mmap(path)?;
-    if document.is_encrypted() || document.was_encrypted() {
-        return Err(PdfOpsError::Unsupported(format!(
-            "encrypted PDFs are not supported: {}",
-            path.display()
-        )));
-    }
+/// Load a whole document eagerly, transparently decrypting encrypted inputs.
+///
+/// lopdf authenticates encrypted PDFs during the load: the empty user
+/// password is tried first (covering the common owner-password-only files),
+/// then `password` when provided. On success every object is decrypted in
+/// memory, so the returned document — and anything saved from it — is
+/// unencrypted.
+pub(crate) fn load_document(path: &Path, password: Option<&str>) -> Result<Document> {
+    let mmap = map_file(path)?;
+    let document = Document::load_mem_with_options(&mmap, load_options(password, None))
+        .map_err(|err| decorate_load_error(err, path))?;
+    ensure_decrypted(&document, path)?;
     if document.page_iter().next().is_none() {
         return Err(PdfOpsError::Range(PageRangeError::NoPages));
     }
     Ok(document)
 }
 
-fn load_document_mmap(path: &Path) -> Result<Document> {
-    let mmap = map_file(path)?;
-    Ok(Document::load_mem_with_options(
-        &mmap,
-        LoadOptions::default(),
-    )?)
+pub(crate) fn load_options(password: Option<&str>, filter: Option<FilterFunc>) -> LoadOptions {
+    LoadOptions {
+        password: password.map(str::to_owned),
+        filter,
+        strict: false,
+    }
+}
+
+/// Map a lopdf load failure to a user-facing error, giving wrong-password
+/// failures a dedicated message.
+pub(crate) fn decorate_load_error(err: lopdf::Error, path: &Path) -> PdfOpsError {
+    match err {
+        lopdf::Error::InvalidPassword => {
+            PdfOpsError::Password(format!("invalid password for {}", path.display()))
+        }
+        err => PdfOpsError::Pdf(err),
+    }
+}
+
+/// Reject documents lopdf could not decrypt during the load, which happens
+/// when an input is encrypted with a non-empty user password and no (or an
+/// empty) password was supplied.
+pub(crate) fn ensure_decrypted(document: &Document, path: &Path) -> Result<()> {
+    if document.is_encrypted() {
+        return Err(PdfOpsError::Password(format!(
+            "{} is encrypted and requires a password; retry with --password",
+            path.display()
+        )));
+    }
+    Ok(())
 }
 
 pub(crate) fn map_file(path: &Path) -> Result<Mmap> {

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     copy::{copy_pages_with_options, CopyOptions},
-    lazy::LazyPdf,
+    lazy::PdfSource,
     load::map_file,
     range::{PageRangeError, PageRangeGroup},
     split::{empty_document, finish_pages},
@@ -20,9 +20,13 @@ pub struct MergeInput {
     pub ranges: Vec<PageRangeGroup>,
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct MergeOptions {
     pub preserve_whole_single_input: bool,
+    /// Password used to decrypt encrypted inputs. The empty user password is
+    /// always tried first, so owner-password-only files merge without this.
+    /// Outputs are always written unencrypted.
+    pub password: Option<String>,
 }
 
 impl MergeInput {
@@ -46,17 +50,18 @@ pub fn merge_with_options(
     if inputs.is_empty() {
         return Err(PdfOpsError::Range(PageRangeError::NoPages));
     }
+    let password = options.password.as_deref();
 
     if options.preserve_whole_single_input {
         if let [input] = inputs {
             if input.ranges.is_empty() && !same_file(&input.path, output)? {
-                return copy_whole_input(input, output);
+                return copy_whole_input(input, output, password);
             }
         }
     }
 
     if inputs.iter().all(|input| input.ranges.is_empty()) {
-        return merge_whole_inputs_streaming(inputs, output);
+        return merge_whole_inputs_streaming(inputs, output, password);
     }
 
     let mut target = empty_document();
@@ -64,7 +69,7 @@ pub fn merge_with_options(
 
     for input in inputs {
         let mmap = map_file(&input.path)?;
-        let source = LazyPdf::parse(&mmap, &input.path)?;
+        let source = PdfSource::open(&mmap, &input.path, password)?;
         let pages = source.page_ids()?;
         let page_ids = resolve_merge_page_ids(&pages, input)?;
         merged_pages.extend(copy_pages_with_options(
@@ -83,9 +88,37 @@ pub fn merge_with_options(
     Ok(())
 }
 
-fn merge_whole_inputs_streaming(inputs: &[MergeInput], output: &Path) -> Result<()> {
+fn merge_whole_inputs_streaming(
+    inputs: &[MergeInput],
+    output: &Path,
+    password: Option<&str>,
+) -> Result<()> {
+    write_streaming_output(output, |writer| {
+        for input in inputs {
+            let mmap = map_file(&input.path)?;
+            let source = PdfSource::open(&mmap, &input.path, password)?;
+            let page_ids = source.page_ids()?;
+            if page_ids.is_empty() {
+                return Err(PdfOpsError::Range(PageRangeError::NoPages));
+            }
+            append_whole_source(writer, &source, &page_ids)?;
+        }
+        Ok(())
+    })
+}
+
+/// Write a streaming merge output atomically: build it in a temporary file
+/// next to `output` and rename it into place on success.
+fn write_streaming_output(
+    output: &Path,
+    fill: impl FnOnce(&mut StreamingPdfWriter) -> Result<()>,
+) -> Result<()> {
     let temp_output = temp_output_path(output)?;
-    let result = merge_whole_inputs_streaming_to_path(inputs, &temp_output);
+    let result = (|| {
+        let mut writer = StreamingPdfWriter::create(&temp_output)?;
+        fill(&mut writer)?;
+        writer.finish()
+    })();
     match result {
         Ok(()) => {
             fs::rename(&temp_output, output)?;
@@ -98,31 +131,23 @@ fn merge_whole_inputs_streaming(inputs: &[MergeInput], output: &Path) -> Result<
     }
 }
 
-fn merge_whole_inputs_streaming_to_path(inputs: &[MergeInput], output: &Path) -> Result<()> {
-    let mut writer = StreamingPdfWriter::create(output)?;
-
-    for input in inputs {
-        let mmap = map_file(&input.path)?;
-        let source = LazyPdf::parse(&mmap, &input.path)?;
-        let page_ids = source.page_ids()?;
-        if page_ids.is_empty() {
-            return Err(PdfOpsError::Range(PageRangeError::NoPages));
-        }
-
-        let copied_pages = {
-            let mut context = StreamingCopyContext::new(
-                &mut writer,
-                CopyOptions {
-                    prune_resources: false,
-                    ..CopyOptions::default()
-                },
-            );
-            context.copy_pages(&source, &page_ids)?
-        };
-        writer.extend_pages(copied_pages);
-    }
-
-    writer.finish()
+fn append_whole_source(
+    writer: &mut StreamingPdfWriter,
+    source: &PdfSource<'_>,
+    page_ids: &[lopdf::ObjectId],
+) -> Result<()> {
+    let copied_pages = {
+        let mut context = StreamingCopyContext::new(
+            writer,
+            CopyOptions {
+                prune_resources: false,
+                ..CopyOptions::default()
+            },
+        );
+        context.copy_pages(source, page_ids)?
+    };
+    writer.extend_pages(copied_pages);
+    Ok(())
 }
 
 fn temp_output_path(output: &Path) -> Result<PathBuf> {
@@ -152,11 +177,21 @@ fn temp_output_path(output: &Path) -> Result<PathBuf> {
     )))
 }
 
-fn copy_whole_input(input: &MergeInput, output: &Path) -> Result<()> {
+/// Fast path for a single whole input: byte-copy it to `output`. Encrypted
+/// inputs cannot be byte-copied because outputs must always be unencrypted,
+/// so the already-decrypted source is rewritten through the streaming writer
+/// instead.
+fn copy_whole_input(input: &MergeInput, output: &Path, password: Option<&str>) -> Result<()> {
     let mmap = map_file(&input.path)?;
-    let source = LazyPdf::parse(&mmap, &input.path)?;
-    if source.page_ids()?.is_empty() {
+    let source = PdfSource::open(&mmap, &input.path, password)?;
+    let page_ids = source.page_ids()?;
+    if page_ids.is_empty() {
         return Err(PdfOpsError::Range(PageRangeError::NoPages));
+    }
+    if source.was_encrypted() {
+        return write_streaming_output(output, |writer| {
+            append_whole_source(writer, &source, &page_ids)
+        });
     }
     fs::copy(&input.path, output)?;
     Ok(())

--- a/src/split.rs
+++ b/src/split.rs
@@ -8,7 +8,7 @@ use rayon::prelude::*;
 
 use crate::{
     copy::{copy_pages, resolve_page_ids, ObjectSource},
-    lazy::LazyPdf,
+    lazy::PdfSource,
     load::{load_document, map_file},
     range::{PageRangeError, PageRangeGroup},
     PdfOpsError, Result,
@@ -21,7 +21,18 @@ pub struct SplitOutput {
 }
 
 pub fn split(input: &Path, outputs: &[SplitOutput]) -> Result<()> {
-    let source = load_document(input)?;
+    split_with_password(input, outputs, None)
+}
+
+/// Like [`split`], additionally decrypting encrypted inputs with `password`
+/// when the empty user password does not authenticate. Outputs are always
+/// written unencrypted.
+pub fn split_with_password(
+    input: &Path,
+    outputs: &[SplitOutput],
+    password: Option<&str>,
+) -> Result<()> {
+    let source = load_document(input, password)?;
     let pages = source.get_pages();
     let resolved_outputs = outputs
         .iter()
@@ -43,16 +54,41 @@ pub fn split(input: &Path, outputs: &[SplitOutput]) -> Result<()> {
 pub struct SplitPagesOptions {
     /// Maximum number of consecutive pages written to each output file.
     pub pages_per_file: usize,
+    /// Password used to decrypt encrypted inputs. The empty user password is
+    /// always tried first, so owner-password-only files split without this.
+    /// Outputs are always written unencrypted.
+    pub password: Option<String>,
 }
 
 impl Default for SplitPagesOptions {
     fn default() -> Self {
-        Self { pages_per_file: 1 }
+        Self {
+            pages_per_file: 1,
+            password: None,
+        }
     }
 }
 
 pub fn split_pages(input: &Path, output_pattern: &str) -> Result<()> {
     split_pages_with_options(input, output_pattern, &SplitPagesOptions::default())
+}
+
+/// Like [`split_pages`], additionally decrypting encrypted inputs with
+/// `password` when the empty user password does not authenticate. Outputs are
+/// always written unencrypted.
+pub fn split_pages_with_password(
+    input: &Path,
+    output_pattern: &str,
+    password: Option<&str>,
+) -> Result<()> {
+    split_pages_with_options(
+        input,
+        output_pattern,
+        &SplitPagesOptions {
+            password: password.map(str::to_owned),
+            ..SplitPagesOptions::default()
+        },
+    )
 }
 
 pub fn split_pages_with_options(
@@ -68,7 +104,7 @@ pub fn split_pages_with_options(
     }
 
     let mmap = map_file(input)?;
-    let source = LazyPdf::parse(&mmap, input)?;
+    let source = PdfSource::open(&mmap, input, options.password.as_deref())?;
     let pages = source.page_ids()?;
     let page_count = pages.len();
     if page_count == 0 {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -27,6 +27,16 @@ fn assert_page_count(path: &Path, expected: usize) {
     );
 }
 
+fn assert_not_encrypted(path: &Path) {
+    let document = Document::load(path)
+        .unwrap_or_else(|err| panic!("failed to load {}: {err}", path.display()));
+    assert!(
+        !document.is_encrypted() && !document.was_encrypted(),
+        "{} should be written unencrypted",
+        path.display()
+    );
+}
+
 #[test]
 fn split_cli_writes_each_requested_range() {
     let temp = tempdir().unwrap();
@@ -103,7 +113,7 @@ fn split_cli_fails_on_missing_input() {
 }
 
 #[test]
-fn split_cli_rejects_encrypted_input() {
+fn split_cli_requires_password_for_user_password_input() {
     let temp = tempdir().unwrap();
     let output = temp.path().join("out.pdf");
 
@@ -115,9 +125,107 @@ fn split_cli_rejects_encrypted_input() {
         .arg(&output)
         .assert()
         .failure()
-        .stderr(predicate::str::contains("unsupported"));
+        .stderr(predicate::str::contains("--password"));
 
     assert!(!output.exists());
+}
+
+#[test]
+fn split_cli_rejects_wrong_password() {
+    let temp = tempdir().unwrap();
+    let output = temp.path().join("out.pdf");
+
+    pdq()
+        .arg("split")
+        .arg(fixture("user-password.pdf"))
+        .arg("--password")
+        .arg("wrong")
+        .arg("--out")
+        .arg("1")
+        .arg(&output)
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid password"));
+
+    assert!(!output.exists());
+}
+
+#[test]
+fn split_cli_decrypts_user_password_input_with_password() {
+    let temp = tempdir().unwrap();
+    let output = temp.path().join("decrypted.pdf");
+
+    pdq()
+        .arg("split")
+        .arg(fixture("user-password.pdf"))
+        .arg("--password")
+        .arg("user")
+        .arg("--out")
+        .arg("1-3")
+        .arg(&output)
+        .assert()
+        .success();
+
+    assert_page_count(&output, 3);
+    assert_not_encrypted(&output);
+}
+
+#[test]
+fn split_pages_cli_decrypts_owner_only_input_without_password() {
+    let temp = tempdir().unwrap();
+
+    pdq()
+        .arg("split-pages")
+        .arg(fixture("owner-only.pdf"))
+        .arg("--output")
+        .arg(temp.path().join("page-%d.pdf"))
+        .assert()
+        .success();
+
+    for page in 1..=11 {
+        let path = temp.path().join(format!("page-{page:02}.pdf"));
+        assert_page_count(&path, 1);
+        assert_not_encrypted(&path);
+    }
+}
+
+#[test]
+fn merge_cli_decrypts_single_encrypted_input() {
+    let temp = tempdir().unwrap();
+    let merged = temp.path().join("merged.pdf");
+
+    pdq()
+        .arg("merge")
+        .arg("--output")
+        .arg(&merged)
+        .arg(fixture("owner-only.pdf"))
+        .assert()
+        .success();
+
+    assert_page_count(&merged, 11);
+    assert_not_encrypted(&merged);
+}
+
+#[test]
+fn page_count_cli_reads_owner_only_encrypted_input_without_password() {
+    pdq()
+        .arg("page-count")
+        .arg(fixture("owner-only.pdf"))
+        .assert()
+        .success()
+        .stdout(predicate::str::diff("11\n"));
+}
+
+#[test]
+fn page_count_cli_reads_user_password_input_with_password() {
+    pdq()
+        .arg("page-count")
+        .arg(fixture("user-password.pdf"))
+        .arg("--password")
+        .arg("user")
+        .assert()
+        .success()
+        .stdout(predicate::str::diff("11\n"));
 }
 
 #[test]
@@ -225,6 +333,30 @@ fn split_pages_cli_chunks_pages_per_file() {
     assert_page_count(&temp.path().join("chunk-2.pdf"), 4);
     assert_page_count(&temp.path().join("chunk-3.pdf"), 3);
     assert!(!temp.path().join("chunk-4.pdf").exists());
+}
+
+#[test]
+fn split_pages_cli_chunks_and_decrypts_with_password() {
+    let temp = tempdir().unwrap();
+
+    pdq()
+        .arg("split-pages")
+        .arg(fixture("user-password.pdf"))
+        .arg("--output")
+        .arg(temp.path().join("chunk-%d.pdf"))
+        .arg("--pages-per-file")
+        .arg("3")
+        .arg("--password")
+        .arg("user")
+        .assert()
+        .success();
+
+    for (chunk, expected_pages) in [(1, 3), (2, 3), (3, 3), (4, 2)] {
+        let path = temp.path().join(format!("chunk-{chunk}.pdf"));
+        assert_page_count(&path, expected_pages);
+        assert_not_encrypted(&path);
+    }
+    assert!(!temp.path().join("chunk-5.pdf").exists());
 }
 
 #[test]

--- a/tests/split_merge.rs
+++ b/tests/split_merge.rs
@@ -6,8 +6,9 @@ use std::{
 
 use lopdf::{dictionary, Dictionary, Document, Object, Stream};
 use pdq::{
-    merge, merge_with_options, page_count, split, split_pages, split_pages_with_options,
-    MergeInput, MergeOptions, PageRangeGroup, PdfOpsError, SplitOutput, SplitPagesOptions,
+    merge, merge_with_options, page_count, page_count_with_password, split, split_pages,
+    split_pages_with_options, split_pages_with_password, split_with_password, MergeInput,
+    MergeOptions, PageRangeGroup, PdfOpsError, SplitOutput, SplitPagesOptions,
 };
 use tempfile::tempdir;
 
@@ -107,6 +108,84 @@ impl QpdfValidator {
         self.check_pdf(path);
         self.assert_npages(path, expected_pages);
     }
+
+    /// Encrypt `source` into `dest` by shelling out to qpdf. Returns `false`
+    /// when qpdf is unavailable so callers can skip the test.
+    fn encrypt(
+        &self,
+        source: &Path,
+        dest: &Path,
+        user_password: &str,
+        owner_password: &str,
+        options: &[&str],
+    ) -> bool {
+        if !self.available {
+            eprintln!(
+                "qpdf unavailable; skipping encrypted fixture {}",
+                dest.display()
+            );
+            return false;
+        }
+
+        let output = Command::new("qpdf")
+            .arg("--allow-weak-crypto")
+            .arg("--encrypt")
+            .arg(user_password)
+            .arg(owner_password)
+            .args(options)
+            .arg("--")
+            .arg(source)
+            .arg(dest)
+            .output()
+            .unwrap_or_else(|err| panic!("failed to run qpdf --encrypt: {err}"));
+        assert!(
+            output.status.success(),
+            "qpdf --encrypt failed for {}\nstdout:\n{}\nstderr:\n{}",
+            dest.display(),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        true
+    }
+
+    fn assert_not_encrypted(&self, path: &Path) {
+        if !self.available {
+            eprintln!(
+                "qpdf unavailable; skipping qpdf --is-encrypted for {}",
+                path.display()
+            );
+            return;
+        }
+
+        let output = Command::new("qpdf")
+            .arg("--is-encrypted")
+            .arg(path)
+            .output()
+            .unwrap_or_else(|err| {
+                panic!(
+                    "failed to run qpdf --is-encrypted {}: {err}",
+                    path.display()
+                )
+            });
+        // qpdf --is-encrypted exits 0 for encrypted files and non-zero otherwise.
+        assert!(
+            !output.status.success(),
+            "{} is unexpectedly encrypted",
+            path.display()
+        );
+    }
+}
+
+/// Assert with lopdf that `path` is written without encryption, so it also
+/// holds when qpdf is unavailable.
+fn assert_decrypted(path: &Path) {
+    let document = Document::load(path)
+        .unwrap_or_else(|err| panic!("failed to load {}: {err}", path.display()));
+    assert!(
+        !document.is_encrypted() && !document.was_encrypted(),
+        "{} should be written unencrypted",
+        path.display()
+    );
 }
 
 #[test]
@@ -254,6 +333,7 @@ fn merge_with_preserve_whole_single_input_copies_bytes() {
         &merged,
         MergeOptions {
             preserve_whole_single_input: true,
+            ..MergeOptions::default()
         },
     )
     .unwrap();
@@ -272,6 +352,7 @@ fn merge_with_preserve_whole_single_input_does_not_truncate_same_file() {
         &input,
         MergeOptions {
             preserve_whole_single_input: true,
+            ..MergeOptions::default()
         },
     )
     .unwrap();
@@ -354,7 +435,10 @@ fn split_pages_with_options_chunks_pages_and_qpdf_validates_page_counts() {
     split_pages_with_options(
         &input,
         pattern.to_str().unwrap(),
-        &SplitPagesOptions { pages_per_file: 2 },
+        &SplitPagesOptions {
+            pages_per_file: 2,
+            ..SplitPagesOptions::default()
+        },
     )
     .unwrap();
 
@@ -377,7 +461,10 @@ fn split_pages_with_options_larger_than_page_count_writes_single_output() {
     split_pages_with_options(
         &input,
         pattern.to_str().unwrap(),
-        &SplitPagesOptions { pages_per_file: 9 },
+        &SplitPagesOptions {
+            pages_per_file: 9,
+            ..SplitPagesOptions::default()
+        },
     )
     .unwrap();
 
@@ -395,7 +482,10 @@ fn split_pages_with_options_rejects_zero_pages_per_file() {
     let error = split_pages_with_options(
         &fixture("11-pages.pdf"),
         pattern.to_str().unwrap(),
-        &SplitPagesOptions { pages_per_file: 0 },
+        &SplitPagesOptions {
+            pages_per_file: 0,
+            ..SplitPagesOptions::default()
+        },
     )
     .unwrap_err();
 
@@ -414,7 +504,10 @@ fn split_pages_with_options_pads_numbers_to_chunk_count_width() {
     split_pages_with_options(
         &input,
         per_page_pattern.to_str().unwrap(),
-        &SplitPagesOptions { pages_per_file: 1 },
+        &SplitPagesOptions {
+            pages_per_file: 1,
+            ..SplitPagesOptions::default()
+        },
     )
     .unwrap();
     for page in 1..=12 {
@@ -425,7 +518,10 @@ fn split_pages_with_options_pads_numbers_to_chunk_count_width() {
     split_pages_with_options(
         &input,
         chunk_pattern.to_str().unwrap(),
-        &SplitPagesOptions { pages_per_file: 5 },
+        &SplitPagesOptions {
+            pages_per_file: 5,
+            ..SplitPagesOptions::default()
+        },
     )
     .unwrap();
 
@@ -436,6 +532,33 @@ fn split_pages_with_options_pads_numbers_to_chunk_count_width() {
         qpdf.validate(&path, expected_pages);
     }
     assert!(!temp.path().join("chunk-4.pdf").exists());
+}
+
+#[test]
+fn split_pages_with_options_chunks_and_decrypts_user_password_input() {
+    let temp = tempdir().unwrap();
+    let pattern = temp.path().join("chunk-%d.pdf");
+
+    // pages_per_file and password must compose: chunk while decrypting.
+    split_pages_with_options(
+        &fixture("user-password.pdf"),
+        pattern.to_str().unwrap(),
+        &SplitPagesOptions {
+            pages_per_file: 3,
+            password: Some("user".to_string()),
+        },
+    )
+    .unwrap();
+
+    let qpdf = QpdfValidator::detect();
+    for (chunk, expected_pages) in [(1, 3), (2, 3), (3, 3), (4, 2)] {
+        let path = temp.path().join(format!("chunk-{chunk}.pdf"));
+        assert_written(&path);
+        assert_decrypted(&path);
+        qpdf.validate(&path, expected_pages);
+        qpdf.assert_not_encrypted(&path);
+    }
+    assert!(!temp.path().join("chunk-5.pdf").exists());
 }
 
 #[test]
@@ -577,7 +700,7 @@ fn split_pages_keeps_page_font_used_by_form_without_resources() {
 }
 
 #[test]
-fn split_rejects_encrypted_inputs_with_unsupported_error() {
+fn split_requires_password_for_user_password_inputs() {
     let temp = tempdir().unwrap();
     let output = temp.path().join("should-not-exist.pdf");
 
@@ -590,30 +713,259 @@ fn split_rejects_encrypted_inputs_with_unsupported_error() {
     )
     .unwrap_err();
 
-    assert!(matches!(error, PdfOpsError::Unsupported(_)));
+    assert!(matches!(error, PdfOpsError::Password(_)));
+    assert!(
+        error.to_string().contains("--password"),
+        "error should point at --password: {error}"
+    );
     assert!(!output.exists());
 }
 
 #[test]
-fn split_pages_rejects_encrypted_inputs_with_unsupported_error() {
+fn split_pages_requires_password_for_user_password_inputs() {
     let temp = tempdir().unwrap();
     let pattern = temp.path().join("should-not-exist-%d.pdf");
 
     let error = split_pages(&fixture("user-password.pdf"), pattern.to_str().unwrap()).unwrap_err();
 
-    assert!(matches!(error, PdfOpsError::Unsupported(_)));
+    assert!(matches!(error, PdfOpsError::Password(_)));
+    assert!(
+        error.to_string().contains("--password"),
+        "error should point at --password: {error}"
+    );
     assert!(!temp.path().join("should-not-exist-1.pdf").exists());
 }
 
 #[test]
-fn merge_rejects_owner_only_encrypted_inputs_with_unsupported_error() {
+fn split_pages_rejects_wrong_password_with_invalid_password_error() {
     let temp = tempdir().unwrap();
-    let output = temp.path().join("should-not-exist.pdf");
+    let pattern = temp.path().join("should-not-exist-%d.pdf");
 
-    let error = merge(&[MergeInput::all(fixture("owner-only.pdf"))], &output).unwrap_err();
+    let error = split_pages_with_password(
+        &fixture("user-password.pdf"),
+        pattern.to_str().unwrap(),
+        Some("wrong"),
+    )
+    .unwrap_err();
 
-    assert!(matches!(error, PdfOpsError::Unsupported(_)));
-    assert!(!output.exists());
+    assert!(matches!(error, PdfOpsError::Password(_)));
+    assert!(
+        error.to_string().contains("invalid password"),
+        "error should report an invalid password: {error}"
+    );
+    assert!(!temp.path().join("should-not-exist-1.pdf").exists());
+}
+
+#[test]
+fn page_count_reads_owner_only_encrypted_input_without_password() {
+    assert_eq!(page_count(&fixture("owner-only.pdf")).unwrap(), 11);
+}
+
+#[test]
+fn page_count_with_password_reads_user_password_input() {
+    assert_eq!(
+        page_count_with_password(&fixture("user-password.pdf"), Some("user")).unwrap(),
+        11
+    );
+}
+
+#[test]
+fn split_with_password_decrypts_user_password_input() {
+    let temp = tempdir().unwrap();
+    let output = temp.path().join("decrypted-1-3.pdf");
+
+    split_with_password(
+        &fixture("user-password.pdf"),
+        &[SplitOutput {
+            range: PageRangeGroup::parse("1-3").unwrap(),
+            path: output.clone(),
+        }],
+        Some("user"),
+    )
+    .unwrap();
+
+    assert_written(&output);
+    assert_decrypted(&output);
+    let qpdf = QpdfValidator::detect();
+    qpdf.validate(&output, 3);
+    qpdf.assert_not_encrypted(&output);
+}
+
+#[test]
+fn split_pages_decrypts_owner_only_encrypted_input_without_password() {
+    let temp = tempdir().unwrap();
+    let pattern = temp.path().join("owner-only-%d.pdf");
+
+    split_pages(&fixture("owner-only.pdf"), pattern.to_str().unwrap()).unwrap();
+
+    let qpdf = QpdfValidator::detect();
+    for page in 1..=11 {
+        let path = temp.path().join(format!("owner-only-{page:02}.pdf"));
+        assert_written(&path);
+        assert_decrypted(&path);
+        qpdf.validate(&path, 1);
+        qpdf.assert_not_encrypted(&path);
+    }
+}
+
+#[test]
+fn merge_decrypts_owner_only_encrypted_input_without_password() {
+    let temp = tempdir().unwrap();
+    let output = temp.path().join("merged.pdf");
+
+    merge(
+        &[
+            MergeInput::all(fixture("owner-only.pdf")),
+            MergeInput::all(fixture("11-pages.pdf")),
+        ],
+        &output,
+    )
+    .unwrap();
+
+    assert_written(&output);
+    assert_decrypted(&output);
+    let qpdf = QpdfValidator::detect();
+    qpdf.validate(&output, 22);
+    qpdf.assert_not_encrypted(&output);
+}
+
+#[test]
+fn merge_preserve_whole_single_encrypted_input_rewrites_decrypted() {
+    let temp = tempdir().unwrap();
+    let output = temp.path().join("merged.pdf");
+
+    // The byte-copy fast path must not apply: it would keep the output
+    // encrypted, while outputs are always written decrypted.
+    merge_with_options(
+        &[MergeInput::all(fixture("owner-only.pdf"))],
+        &output,
+        MergeOptions {
+            preserve_whole_single_input: true,
+            ..MergeOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_written(&output);
+    assert_decrypted(&output);
+    let qpdf = QpdfValidator::detect();
+    qpdf.validate(&output, 11);
+    qpdf.assert_not_encrypted(&output);
+}
+
+#[test]
+fn merge_with_password_merges_ranges_from_user_password_input() {
+    let temp = tempdir().unwrap();
+    let output = temp.path().join("merged-ranges.pdf");
+
+    merge_with_options(
+        &[MergeInput {
+            path: fixture("user-password.pdf"),
+            ranges: vec![PageRangeGroup::parse("1-2").unwrap()],
+        }],
+        &output,
+        MergeOptions {
+            password: Some("user".to_string()),
+            ..MergeOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_written(&output);
+    assert_decrypted(&output);
+    let qpdf = QpdfValidator::detect();
+    qpdf.validate(&output, 2);
+    qpdf.assert_not_encrypted(&output);
+}
+
+#[test]
+fn split_pages_decrypts_aes128_encrypted_input() {
+    let qpdf = QpdfValidator::detect();
+    let temp = tempdir().unwrap();
+    let encrypted = temp.path().join("aes128.pdf");
+    if !qpdf.encrypt(
+        &fixture("11-pages.pdf"),
+        &encrypted,
+        "",
+        "ownerpw",
+        &["128", "--use-aes=y"],
+    ) {
+        return;
+    }
+
+    let pattern = temp.path().join("aes128-%d.pdf");
+    split_pages(&encrypted, pattern.to_str().unwrap()).unwrap();
+
+    for page in 1..=11 {
+        let path = temp.path().join(format!("aes128-{page:02}.pdf"));
+        assert_written(&path);
+        assert_decrypted(&path);
+        qpdf.validate(&path, 1);
+        qpdf.assert_not_encrypted(&path);
+    }
+}
+
+#[test]
+fn split_decrypts_rc4_encrypted_input() {
+    let qpdf = QpdfValidator::detect();
+    let temp = tempdir().unwrap();
+    let encrypted = temp.path().join("rc4.pdf");
+    if !qpdf.encrypt(
+        &fixture("11-pages.pdf"),
+        &encrypted,
+        "",
+        "ownerpw",
+        &["128", "--use-aes=n"],
+    ) {
+        return;
+    }
+
+    let output = temp.path().join("rc4-1-3.pdf");
+    split(
+        &encrypted,
+        &[SplitOutput {
+            range: PageRangeGroup::parse("1-3").unwrap(),
+            path: output.clone(),
+        }],
+    )
+    .unwrap();
+
+    assert_written(&output);
+    assert_decrypted(&output);
+    qpdf.validate(&output, 3);
+    qpdf.assert_not_encrypted(&output);
+}
+
+#[test]
+fn merge_with_password_decrypts_aes256_user_password_input() {
+    let qpdf = QpdfValidator::detect();
+    let temp = tempdir().unwrap();
+    let encrypted = temp.path().join("aes256-user.pdf");
+    if !qpdf.encrypt(
+        &fixture("11-pages.pdf"),
+        &encrypted,
+        "userpw",
+        "ownerpw",
+        &["256"],
+    ) {
+        return;
+    }
+
+    let output = temp.path().join("merged.pdf");
+    merge_with_options(
+        &[MergeInput::all(&encrypted)],
+        &output,
+        MergeOptions {
+            password: Some("userpw".to_string()),
+            ..MergeOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_written(&output);
+    assert_decrypted(&output);
+    qpdf.validate(&output, 11);
+    qpdf.assert_not_encrypted(&output);
 }
 
 #[test]


### PR DESCRIPTION
## What

Adds qpdf-style decrypt-on-read support for encrypted PDFs (RC4, AES-128, AES-256) to all four subcommands: `split`, `split-pages`, `merge`, and `page-count`.

- Files encrypted with only an owner password (empty user password — the common case) work with no flags.
- Files with a real user/owner password take a new `--password <PASSWORD>` option on `split`, `split-pages`, `merge`, and `page-count`.
- `render` (merged from #3 after this branched; rebased on top) is untouched: it goes through hayro's own parser, which also opens owner-password-only files by itself but has no password option, so real-user-password PDFs still fail to render with a clear error.
- Outputs are always written decrypted, like `qpdf --decrypt`.
- Clear failures: an encrypted file without a valid password reports `... is encrypted and requires a password; retry with --password`, and a wrong password reports `invalid password for ...` — both with a non-zero exit.

```sh
pdq page-count owner-password-only.pdf            # just works
pdq split-pages --password secret --output 'page-%d.pdf' encrypted.pdf
```

## How

lopdf authenticates encrypted PDFs during the load (empty user password first, then the supplied one) and decrypts every object in memory, so anything saved afterwards is unencrypted. The eager path (`split`) just threads the password through `LoadOptions`.

The lazy mmap-backed reader used by `split-pages`, `merge`, and `page-count` cannot serve encrypted inputs — it parses raw, still-encrypted bytes on demand. But lopdf ignores the metadata-only filter for encrypted PDFs and materializes a fully decrypted document during that same load, so the new internal `PdfSource` enum simply keeps that eager document for encrypted inputs and falls back to it, at zero extra cost. Unencrypted inputs keep the exact same lazy fast path as before.

The merge byte-copy fast path (`preserve_whole_single_input`) is skipped for encrypted inputs, since copying bytes would keep the output encrypted; those are rewritten through the streaming writer instead.

## Library API

- `split_with_password`, `split_pages_with_password`, `page_count_with_password` (existing functions remain as thin wrappers)
- `MergeOptions` gains a `password: Option<String>` field (still `Default`; no longer `Copy`)
- `SplitPagesOptions` (from #4, rebased on top) also gains `password: Option<String>`, and `split_pages_with_options` is the single implementation both `split_pages` and `split_pages_with_password` wrap — so `--pages-per-file` chunking and `--password` compose in one call: `pdq split-pages --output 'chunk-%d.pdf' --pages-per-file 3 --password pw encrypted.pdf` chunks and decrypts (covered by library and CLI tests)
- New `PdfOpsError::Password` variant for missing/invalid password failures

## Tests

- Checked-in AES-256 fixtures (`owner-only.pdf`, `user-password.pdf`) cover the no-flag, `--password`, missing-password, and wrong-password paths at both the library and CLI level, including the merge single-input fast path.
- AES-128, RC4, and a fresh AES-256 user-password fixture are generated at test time by shelling out to qpdf (skipped when qpdf is unavailable, matching the existing `QpdfValidator` pattern).
- All decrypted outputs are validated with `qpdf --check` / `--show-npages`, asserted not encrypted via `qpdf --is-encrypted` and an lopdf-based check that also runs without qpdf.

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` (70 tests) all pass.


