### PR TITLE
feat(repair): best-effort xref reconstruction for damaged files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,6 +1031,7 @@ dependencies = [
  "flate2",
  "hayro",
  "lopdf",
+ "memchr",
  "memmap2",
  "predicates",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ render = ["dep:hayro"]
 clap = { version = "4.6.1", features = ["derive"] }
 hayro = { version = "0.7.1", features = ["embed-fonts"], optional = true }
 lopdf = "0.43.0"
+memchr = "2.7"
 memmap2 = "0.9.9"
 rayon = "1.12.0"
 thiserror = "2.0.17"

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Runtime constraints:
 
 The first implementation uses `lopdf` as a pure-Rust PDF object model and
 writer. It focuses on valid split/merge outputs for ordinary PDFs. Advanced
-qpdf behavior such as repair, linearization, forms, outlines, and full
-compatibility with unusual historical PDFs is intentionally out of scope for
-the current MVP.
+qpdf behavior such as linearization, forms, outlines, and full compatibility
+with unusual historical PDFs is intentionally out of scope for the current
+MVP. Damaged cross-reference data is the one repair pdq performs — see
+[Repair](#repair).
 
 Encrypted PDFs (RC4, AES-128, AES-256) are supported as inputs: files are
 decrypted while loading, and outputs are always written unencrypted (like
@@ -51,6 +52,24 @@ of `split`, `split-pages`, and `merge` are written decrypted either way.
 
 Tests may use `qpdf` as a development validator when it is available on `PATH`.
 The runtime implementation must remain qpdf-free.
+
+## Repair
+
+Files with damaged cross-reference data — truncated or garbage xref tables,
+destroyed trailers, tables whose offsets point at the wrong objects — are
+repaired automatically, the way qpdf, Poppler, and pdf.js recover them: the
+raw file is scanned for `N G obj` headers and the cross-reference table is
+rebuilt from what is actually there (best effort). Repair is strictly a last
+resort and never runs on well-formed files: it only starts after the normal
+parse fails, or after a fetch proves the xref lies about an offset, so
+healthy files pay nothing for it. A repaired read emits one warning line on
+stderr, and outputs built from a repaired source are always full rewrites
+with a fresh, valid xref — never byte copies of the damage.
+
+Two classes stay hard errors by design: encrypted files with damaged xref
+data (repair cannot decrypt; the error suggests a dedicated repair tool), and
+files where no catalog can be recovered at all. In both cases the error names
+the damaged cross-reference data rather than a generic parse failure.
 
 ## Render
 

--- a/src/count.rs
+++ b/src/count.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::{lazy::PdfSource, load::map_file, Result};
+use crate::{load::map_file, repair::with_repair_retry, Result};
 
 /// Count the pages in a PDF by walking the page tree (validated count).
 ///
@@ -45,19 +45,22 @@ fn count_impl(input: &Path, password: Option<&str>, strict: bool) -> Result<usiz
     let timing = std::env::var_os("PDQ_TIMING").is_some();
     let start = std::time::Instant::now();
     let mmap = map_file(input)?;
-    let source = PdfSource::open(&mmap, input, password)?;
-    if timing {
-        eprintln!("phase parse: {:?}", start.elapsed());
-    }
-    let count_start = std::time::Instant::now();
-    let count = if strict {
-        source.count_pages()
-    } else {
-        source.count_pages_fast()
-    };
-    if timing {
-        let phase = if strict { "walk" } else { "count" };
-        eprintln!("phase {phase}: {:?}", count_start.elapsed());
-    }
-    count
+    // Damaged inputs whose xref lies about offsets get one retry against a
+    // reconstructed table; the closure re-runs (and re-logs) in that case.
+    with_repair_retry(&mmap, input, password, |source| {
+        if timing {
+            eprintln!("phase parse: {:?}", start.elapsed());
+        }
+        let count_start = std::time::Instant::now();
+        let count = if strict {
+            source.count_pages()
+        } else {
+            source.count_pages_fast()
+        };
+        if timing {
+            let phase = if strict { "walk" } else { "count" };
+            eprintln!("phase {phase}: {:?}", count_start.elapsed());
+        }
+        count
+    })
 }

--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -9,7 +9,7 @@ use lopdf::{xref::XrefEntry, Document, Object, ObjectId, ObjectStream, Reader};
 
 use crate::{
     copy::ObjectSource,
-    load::{decorate_load_error, ensure_decrypted, load_options},
+    load::{decorate_load_error, ensure_decrypted, load_options, upgrade_damaged_xref_error},
     PdfOpsError, Result,
 };
 
@@ -61,20 +61,66 @@ impl<'a> PdfSource<'a> {
         // parse below so behavior is identical to the slow path.
         if let Some(document) = crate::xrefboot::bootstrap_document(buffer) {
             if !document.is_encrypted() && !document.was_encrypted() {
-                return Ok(Self::Lazy(LazyPdf::new(buffer, document)?));
+                // A bootstrap that parses but fails validation (e.g. a
+                // compressed entry naming a non-normal container) is damage
+                // the full parse or the repair scan may untangle, so only a
+                // success returns early.
+                if let Ok(lazy) = LazyPdf::new(buffer, document, false) {
+                    return Ok(Self::Lazy(lazy));
+                }
             }
         } else if std::env::var_os("PDQ_TIMING").is_some() {
             eprintln!("phase parse: xref bootstrap fell back to full lopdf parse");
         }
 
-        let document =
-            Document::load_mem_with_options(buffer, load_options(password, Some(drop_object)))
-                .map_err(|err| decorate_load_error(err, path))?;
+        let document = match Document::load_mem_with_options(
+            buffer,
+            load_options(password, Some(drop_object)),
+        ) {
+            Ok(document) => document,
+            // A wrong password keeps its dedicated error: the file is not
+            // damaged and reconstruction could not decrypt it anyway.
+            Err(err @ lopdf::Error::InvalidPassword) => return Err(decorate_load_error(err, path)),
+            // Last chance (issue #14): the xref/trailer data is unusable, so
+            // rebuild it from a raw object scan. Only already-failing files
+            // reach this, so well-formed inputs never pay for it.
+            Err(err) => {
+                return match Self::open_repaired(buffer, path) {
+                    Some(source) => Ok(source),
+                    None => Err(upgrade_damaged_xref_error(err, path)),
+                }
+            }
+        };
         ensure_decrypted(&document, path)?;
         if document.was_encrypted() {
             return Ok(Self::Eager(document));
         }
-        Ok(Self::Lazy(LazyPdf::new(buffer, document)?))
+        Ok(Self::Lazy(LazyPdf::new(buffer, document, false)?))
+    }
+
+    /// Open by reconstructing the xref from a raw object scan, bypassing the
+    /// file's own (damaged) cross-reference data entirely. `None` when the
+    /// buffer cannot be repaired — encrypted, or no recoverable catalog —
+    /// in which case callers surface their original error.
+    pub(crate) fn open_repaired(buffer: &'a [u8], path: &Path) -> Option<Self> {
+        let document = crate::repair::reconstruct_document(buffer)?;
+        let lazy = LazyPdf::new(buffer, document, true).ok()?;
+        eprintln!(
+            "pdq: warning: {}: damaged cross-reference data; reconstructed by \
+             scanning the file (best effort)",
+            path.display()
+        );
+        Some(Self::Lazy(lazy))
+    }
+
+    /// True when the source was built from a reconstructed xref. Repaired
+    /// sources must be rewritten — never byte-copied — so outputs get a
+    /// valid cross-reference table instead of a copy of the damage.
+    pub(crate) fn repaired(&self) -> bool {
+        match self {
+            Self::Lazy(lazy) => lazy.repaired,
+            Self::Eager(_) => false,
+        }
     }
 
     pub(crate) fn page_ids(&self) -> Result<Vec<ObjectId>> {
@@ -134,12 +180,14 @@ pub(crate) struct LazyPdf<'a> {
     reader: Reader<'a>,
     object_streams: Mutex<ObjectStreamCache>,
     normal_objects: NormalObjectCache,
+    /// True when the reference table was reconstructed by `crate::repair`.
+    repaired: bool,
 }
 
 impl<'a> LazyPdf<'a> {
     /// Build the lazy reader from a metadata-only `Document` (trailer and
     /// xref, no objects) previously loaded from `buffer`.
-    fn new(buffer: &'a [u8], document: Document) -> Result<Self> {
+    fn new(buffer: &'a [u8], document: Document, repaired: bool) -> Result<Self> {
         let reader = Reader {
             buffer,
             document,
@@ -153,6 +201,7 @@ impl<'a> LazyPdf<'a> {
             reader,
             object_streams: Mutex::new(ObjectStreamCache::default()),
             normal_objects: NormalObjectCache::default(),
+            repaired,
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod merge;
 pub mod range;
 #[cfg(feature = "render")]
 pub mod render;
+mod repair;
 mod scan;
 pub mod split;
 mod split_template;

--- a/src/load.rs
+++ b/src/load.rs
@@ -46,6 +46,39 @@ pub(crate) fn decorate_load_error(err: lopdf::Error, path: &Path) -> PdfOpsError
     }
 }
 
+/// Load failed AND reconstruction failed: name the real problem — damaged
+/// cross-reference data — instead of lopdf's generic parse error, and point
+/// at dedicated repair tooling (issue #14). Errors outside that class (bad
+/// header, I/O, …) keep their original message.
+pub(crate) fn upgrade_damaged_xref_error(err: lopdf::Error, path: &Path) -> PdfOpsError {
+    let xref_class = match &err {
+        lopdf::Error::Xref(_)
+        | lopdf::Error::ObjectIdMismatch
+        | lopdf::Error::IndirectObject { .. } => true,
+        // `ParseError` is not re-exported by lopdf, so classify the inner
+        // error by its message: trailer/xref parse failures and truncation
+        // are xref damage, while e.g. "invalid file header" (not a PDF at
+        // all) keeps its original message.
+        lopdf::Error::Parse(inner) => {
+            let message = inner.to_string();
+            message.contains("trailer")
+                || message.contains("cross reference")
+                || message.contains("end of input")
+        }
+        _ => false,
+    };
+    if xref_class {
+        PdfOpsError::InvalidStructure(format!(
+            "{}: damaged cross-reference table or trailer ({err}); automatic repair \
+             failed — a dedicated repair tool (e.g. `qpdf file.pdf repaired.pdf`) may \
+             still recover it",
+            path.display()
+        ))
+    } else {
+        decorate_load_error(err, path)
+    }
+}
+
 /// Reject documents lopdf could not decrypt during the load, which happens
 /// when an input is encrypted with a non-empty user password and no (or an
 /// empty) password was supplied.

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeSet,
     fs::{self, OpenOptions},
     path::{Path, PathBuf},
     process,
@@ -9,6 +10,7 @@ use crate::{
     lazy::PdfSource,
     load::map_file,
     range::{PageRangeError, PageRangeGroup},
+    repair::{is_offset_damage, with_repair_retry},
     split::{empty_document, finish_pages},
     write::{StreamingCopyContext, StreamingPdfWriter},
     PdfOpsError, Result,
@@ -64,28 +66,68 @@ pub fn merge_with_options(
         return merge_whole_inputs_streaming(inputs, output, password);
     }
 
-    let mut target = empty_document();
-    let mut merged_pages = Vec::new();
+    // A fetch error that proves an input's xref lies restarts the merge with
+    // that input force-repaired (the in-progress target document is tainted
+    // by the failed copy). Each restart adds one input to the repair set, so
+    // the loop is bounded by the input count.
+    let mut force_repair: BTreeSet<usize> = BTreeSet::new();
+    'attempt: loop {
+        let mut target = empty_document();
+        let mut merged_pages = Vec::new();
 
-    for input in inputs {
-        let mmap = map_file(&input.path)?;
-        let source = PdfSource::open(&mmap, &input.path, password)?;
-        let pages = source.page_ids()?;
-        let page_ids = resolve_merge_page_ids(&pages, input)?;
-        merged_pages.extend(copy_pages_with_options(
-            &source,
-            &mut target,
-            &page_ids,
-            CopyOptions {
-                prune_resources: !input.ranges.is_empty(),
-                ..CopyOptions::default()
-            },
-        )?);
+        for (index, input) in inputs.iter().enumerate() {
+            let mmap = map_file(&input.path)?;
+            let source =
+                open_merge_source(&mmap, &input.path, password, force_repair.contains(&index))?;
+            let copied = (|| {
+                let pages = source.page_ids()?;
+                let page_ids = resolve_merge_page_ids(&pages, input)?;
+                copy_pages_with_options(
+                    &source,
+                    &mut target,
+                    &page_ids,
+                    CopyOptions {
+                        prune_resources: !input.ranges.is_empty(),
+                        ..CopyOptions::default()
+                    },
+                )
+            })();
+            match copied {
+                Ok(pages) => merged_pages.extend(pages),
+                Err(err) if is_offset_damage(&err) && !source.repaired() => {
+                    force_repair.insert(index);
+                    continue 'attempt;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+
+        finish_pages(&mut target, &merged_pages)?;
+        target.save(output)?;
+        return Ok(());
     }
+}
 
-    finish_pages(&mut target, &merged_pages)?;
-    target.save(output)?;
-    Ok(())
+/// Open one merge input, forcing xref reconstruction for inputs a previous
+/// attempt proved damaged. A forced reconstruction that fails is a hard
+/// error: the damage is already established, there is nothing to fall back
+/// to.
+fn open_merge_source<'a>(
+    buffer: &'a [u8],
+    path: &Path,
+    password: Option<&str>,
+    force_repair: bool,
+) -> Result<PdfSource<'a>> {
+    if force_repair {
+        PdfSource::open_repaired(buffer, path).ok_or_else(|| {
+            PdfOpsError::InvalidStructure(format!(
+                "{}: damaged cross-reference data; automatic repair failed",
+                path.display()
+            ))
+        })
+    } else {
+        PdfSource::open(buffer, path, password)
+    }
 }
 
 fn merge_whole_inputs_streaming(
@@ -93,18 +135,41 @@ fn merge_whole_inputs_streaming(
     output: &Path,
     password: Option<&str>,
 ) -> Result<()> {
-    write_streaming_output(output, |writer| {
-        for input in inputs {
-            let mmap = map_file(&input.path)?;
-            let source = PdfSource::open(&mmap, &input.path, password)?;
-            let page_ids = source.page_ids()?;
-            if page_ids.is_empty() {
-                return Err(PdfOpsError::Range(PageRangeError::NoPages));
+    // Same restart discipline as the ranged merge above: a lying xref aborts
+    // the streaming write (its temp file is discarded) and the whole merge
+    // re-runs with the failing input force-repaired.
+    let mut force_repair: BTreeSet<usize> = BTreeSet::new();
+    loop {
+        let mut failed_index = None;
+        let result = write_streaming_output(output, |writer| {
+            for (index, input) in inputs.iter().enumerate() {
+                let mmap = map_file(&input.path)?;
+                let source =
+                    open_merge_source(&mmap, &input.path, password, force_repair.contains(&index))?;
+                let appended = (|| {
+                    let page_ids = source.page_ids()?;
+                    if page_ids.is_empty() {
+                        return Err(PdfOpsError::Range(PageRangeError::NoPages));
+                    }
+                    append_whole_source(writer, &source, &page_ids)
+                })();
+                if let Err(err) = appended {
+                    if !source.repaired() {
+                        failed_index = Some(index);
+                    }
+                    return Err(err);
+                }
             }
-            append_whole_source(writer, &source, &page_ids)?;
+            Ok(())
+        });
+        match result {
+            Err(err) if is_offset_damage(&err) => match failed_index {
+                Some(index) if force_repair.insert(index) => continue,
+                _ => return Err(err),
+            },
+            result => return result,
         }
-        Ok(())
-    })
+    }
 }
 
 /// Write a streaming merge output atomically: build it in a temporary file
@@ -179,22 +244,24 @@ fn temp_output_path(output: &Path) -> Result<PathBuf> {
 
 /// Fast path for a single whole input: byte-copy it to `output`. Encrypted
 /// inputs cannot be byte-copied because outputs must always be unencrypted,
-/// so the already-decrypted source is rewritten through the streaming writer
-/// instead.
+/// and repaired inputs cannot either — a byte copy would faithfully preserve
+/// the damaged xref the repair just worked around — so both are rewritten
+/// through the streaming writer instead.
 fn copy_whole_input(input: &MergeInput, output: &Path, password: Option<&str>) -> Result<()> {
     let mmap = map_file(&input.path)?;
-    let source = PdfSource::open(&mmap, &input.path, password)?;
-    let page_ids = source.page_ids()?;
-    if page_ids.is_empty() {
-        return Err(PdfOpsError::Range(PageRangeError::NoPages));
-    }
-    if source.was_encrypted() {
-        return write_streaming_output(output, |writer| {
-            append_whole_source(writer, &source, &page_ids)
-        });
-    }
-    fs::copy(&input.path, output)?;
-    Ok(())
+    with_repair_retry(&mmap, &input.path, password, |source| {
+        let page_ids = source.page_ids()?;
+        if page_ids.is_empty() {
+            return Err(PdfOpsError::Range(PageRangeError::NoPages));
+        }
+        if source.was_encrypted() || source.repaired() {
+            return write_streaming_output(output, |writer| {
+                append_whole_source(writer, source, &page_ids)
+            });
+        }
+        fs::copy(&input.path, output)?;
+        Ok(())
+    })
 }
 
 #[cfg(unix)]

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -1,0 +1,800 @@
+//! Best-effort cross-reference reconstruction for damaged files.
+//!
+//! Scope decision from issue #14: pdq repairs files whose xref/trailer data is
+//! damaged, using the same recovery strategy qpdf, Poppler, pdf.js and mutool
+//! converge on — sweep the raw buffer for `N G obj` headers and rebuild the
+//! cross-reference table from what is actually in the file, ignoring the
+//! damaged table entirely.
+//!
+//! Two properties keep this free for well-formed files:
+//!
+//! * It never runs eagerly. Callers reach it only after the normal parse
+//!   fails (load time) or after a fetch proves the xref lies about an offset
+//!   (fetch time, see [`is_offset_damage`]) — error paths a healthy file
+//!   never enters.
+//! * Its output is the same metadata-only `Document` (reference table +
+//!   trailer) that `crate::xrefboot` produces, wrapped in the same lazy
+//!   reader. There is no separate "repaired" pipeline: downstream count,
+//!   copy, split, merge, and write behavior is identical by construction.
+//!
+//! Encrypted files are never repaired: the lazy reader would hand out
+//! still-encrypted bytes, so those inputs keep today's hard error and are
+//! qpdf territory. Outputs produced from a repaired source are always full
+//! rewrites — the merge byte-copy fast path refuses repaired sources so
+//! damage is never copied through verbatim.
+
+use std::collections::{BTreeMap, HashSet};
+use std::path::Path;
+
+use lopdf::{
+    xref::{Xref, XrefEntry, XrefType},
+    Dictionary, Document, Object, ObjectId, Reader,
+};
+use memchr::memmem;
+
+use crate::{
+    lazy::PdfSource,
+    xrefboot::{is_delimiter, is_whitespace, parse_version, Lexer},
+    PdfOpsError, Result,
+};
+
+/// `XrefEntry::Compressed` indexes are u16, so an object stream can
+/// contribute at most this many recovered entries.
+const MAX_OBJSTM_ENTRIES: usize = u16::MAX as usize + 1;
+
+/// True for fetch-time errors that prove the cross-reference table lies about
+/// an offset: the recorded position holds a different object, or bytes that
+/// are not an object at all. These — and only these — justify a repair retry.
+/// `ObjectNotFound`/`MissingXrefEntry` must NOT trigger one: dangling
+/// references are common in perfectly valid files and are already tolerated
+/// as `Null` by the copy paths, so treating them as damage would run a
+/// full-buffer scan on healthy inputs.
+pub(crate) fn is_offset_damage(err: &PdfOpsError) -> bool {
+    matches!(
+        err,
+        PdfOpsError::Pdf(lopdf::Error::ObjectIdMismatch | lopdf::Error::IndirectObject { .. })
+    )
+}
+
+/// Run `operation` over a lazily opened source, retrying exactly once with a
+/// force-reconstructed source when the first run fails with an error that
+/// proves the xref lies (see [`is_offset_damage`]). This is the wrapper for
+/// single-input operations: the whole operation re-runs against the repaired
+/// source, so the recovered table replaces the damaged one wholesale (qpdf
+/// semantics) instead of mixing entries from both.
+///
+/// Healthy files pay nothing: the retry branch sits on the error path, and a
+/// successful first run returns untouched.
+pub(crate) fn with_repair_retry<'a, T>(
+    buffer: &'a [u8],
+    path: &Path,
+    password: Option<&str>,
+    operation: impl Fn(&PdfSource<'a>) -> Result<T>,
+) -> Result<T> {
+    let source = PdfSource::open(buffer, path, password)?;
+    match operation(&source) {
+        Err(err) if is_offset_damage(&err) && !source.repaired() => {
+            match PdfSource::open_repaired(buffer, path) {
+                Some(repaired) => operation(&repaired),
+                // Unrepairable: surface the original failure, not a new one.
+                None => Err(err),
+            }
+        }
+        result => result,
+    }
+}
+
+/// Rebuild a metadata-only `Document` (reference table + trailer) by scanning
+/// `buffer` for object headers, ignoring the file's own xref data entirely.
+/// Returns `None` when the buffer cannot be repaired — encrypted, no
+/// recoverable objects, or no root that resolves to a catalog — in which case
+/// callers surface their original error.
+pub(crate) fn reconstruct_document(buffer: &[u8]) -> Option<Document> {
+    // Encrypted inputs cannot be repaired: object streams and strings would
+    // come out still encrypted. The token search is conservative (a literal
+    // "/Encrypt" inside page content also refuses), but a false hit only
+    // means keeping today's hard error instead of attempting repair.
+    if memmem::find(buffer, b"/Encrypt").is_some() {
+        return None;
+    }
+
+    let headers = scan_object_headers(buffer);
+    if headers.is_empty() {
+        return None;
+    }
+
+    // Classify the recovered objects by their header dictionary: catalogs
+    // (root fallback), object streams (their members need Compressed
+    // entries), and xref streams (whose dict doubles as a trailer).
+    let mut catalogs: Vec<(u32, ObjectId)> = Vec::new();
+    let mut object_streams: Vec<ObjStmCandidate> = Vec::new();
+    let mut xref_trailers: Vec<(u32, Dictionary)> = Vec::new();
+    for (&id, header) in &headers {
+        let Some((dict, dict_end)) = parse_header_dict(buffer, header.offset) else {
+            continue;
+        };
+        match dict.get(b"Type").ok().and_then(|t| t.as_name().ok()) {
+            Some(b"Catalog") => catalogs.push((header.offset, (id, header.generation))),
+            Some(b"ObjStm") => object_streams.push(ObjStmCandidate {
+                container: id,
+                dict,
+                dict_end,
+            }),
+            Some(b"XRef") => xref_trailers.push((header.offset, dict)),
+            _ => {}
+        }
+    }
+
+    let trailer_source = recover_trailer_dict(buffer, &xref_trailers);
+
+    // Root candidates in order of trust: the recovered trailer's /Root
+    // (generation normalized to the scanned header when they disagree, since
+    // lookups resolve strictly by (id, generation)), then the catalog object
+    // that appears last in the file. When neither exists the catalog may
+    // live compressed inside an object stream, so the expansion below is
+    // asked to look for one among the members it decodes.
+    let mut root_candidates: Vec<ObjectId> = Vec::new();
+    if let Some(dict) = &trailer_source {
+        if let Ok(root) = dict.get(b"Root").and_then(Object::as_reference) {
+            root_candidates.push(match headers.get(&root.0) {
+                Some(header) if header.generation != root.1 => (root.0, header.generation),
+                _ => root,
+            });
+        }
+    }
+    if let Some(&(_, id)) = catalogs.iter().max_by_key(|(offset, _)| *offset) {
+        if !root_candidates.contains(&id) {
+            root_candidates.push(id);
+        }
+    }
+    let scan_members_for_catalog = root_candidates.is_empty();
+
+    let mut entries: BTreeMap<u32, XrefEntry> = headers
+        .iter()
+        .map(|(&id, header)| {
+            (
+                id,
+                XrefEntry::Normal {
+                    offset: header.offset,
+                    generation: header.generation,
+                },
+            )
+        })
+        .collect();
+    let mut member_catalogs: Vec<ObjectId> = Vec::new();
+    for candidate in &object_streams {
+        // Best effort: an object stream that cannot be decoded just
+        // contributes nothing; its members stay unresolvable.
+        let _ = expand_object_stream(
+            buffer,
+            &headers,
+            candidate,
+            &mut entries,
+            scan_members_for_catalog.then_some(&mut member_catalogs),
+        );
+    }
+    root_candidates.extend(member_catalogs);
+    if root_candidates.is_empty() {
+        return None;
+    }
+
+    let version = recover_version(buffer);
+    let max_id = *entries.keys().next_back()?;
+    let mut xref = Xref::new(max_id.checked_add(1)?, XrefType::CrossReferenceTable);
+    xref.entries = entries;
+
+    let mut document = Document::new();
+    document.version = version;
+    document.max_id = max_id;
+    document.reference_table = xref;
+
+    // The recovered table is only trusted when a root candidate actually
+    // resolves to a catalog-shaped dictionary through it.
+    for root in root_candidates {
+        let mut trailer = Dictionary::new();
+        trailer.set("Size", i64::from(max_id) + 1);
+        trailer.set("Root", Object::Reference(root));
+        if let Some(source) = &trailer_source {
+            for key in [b"Info".as_slice(), b"ID".as_slice()] {
+                if let Ok(value) = source.get(key) {
+                    trailer.set(key, value.clone());
+                }
+            }
+        }
+        document.trailer = trailer;
+        let (returned, is_catalog) = root_resolves_to_catalog(buffer, document, root);
+        document = returned;
+        if is_catalog {
+            return Some(document);
+        }
+    }
+    None
+}
+
+/// One recovered `N G obj` header. `offset` points at the first digit of the
+/// object number, computed from the header's real position in the buffer —
+/// which makes the recovered table immune to the junk-before-`%PDF-` and
+/// offset-relative-to-header problems of the original xref.
+struct ScannedHeader {
+    offset: u32,
+    generation: u16,
+}
+
+/// Sweep the buffer for `N G obj` headers. Later occurrences of an id win,
+/// approximating incremental-update semantics: an appended replacement sits
+/// after the object it supersedes.
+fn scan_object_headers(buffer: &[u8]) -> BTreeMap<u32, ScannedHeader> {
+    let mut headers = BTreeMap::new();
+    for pos in memmem::find_iter(buffer, b"obj") {
+        if let Some((id, header)) = parse_header_at(buffer, pos) {
+            headers.insert(id, header);
+        }
+    }
+    headers
+}
+
+/// Validate and parse the `N G obj` header whose `obj` keyword starts at
+/// `keyword_pos`, walking backwards over the generation and object number.
+fn parse_header_at(buffer: &[u8], keyword_pos: usize) -> Option<(u32, ScannedHeader)> {
+    // `obj` must end at a token boundary (`objx` is not a keyword).
+    if let Some(&byte) = buffer.get(keyword_pos + 3) {
+        if !is_whitespace(byte) && !is_delimiter(byte) {
+            return None;
+        }
+    }
+
+    let gen_end = skip_whitespace_backwards(buffer, keyword_pos)?;
+    let (gen_start, generation) = parse_digits_backwards(buffer, gen_end)?;
+    let generation = u16::try_from(generation).ok()?;
+    let id_end = skip_whitespace_backwards(buffer, gen_start)?;
+    let (id_start, id) = parse_digits_backwards(buffer, id_end)?;
+    let id = u32::try_from(id).ok().filter(|id| *id > 0)?;
+
+    // The object number must start at a token boundary, so `/F12 0 obj`
+    // inside a content stream does not register as object 12.
+    if id_start > 0 {
+        let byte = buffer[id_start - 1];
+        if !is_whitespace(byte) && !is_delimiter(byte) {
+            return None;
+        }
+    }
+
+    // Plausibility: the bytes after `obj` must begin a PDF object (or an
+    // empty object's `endobj`), which filters most `N G obj` lookalikes
+    // inside string and stream payloads.
+    let mut lexer = Lexer {
+        buffer,
+        pos: keyword_pos + 3,
+    };
+    lexer.skip_whitespace();
+    if !matches!(
+        lexer.peek(),
+        Some(
+            b'<' | b'[' | b'/' | b'(' | b'+' | b'-' | b'.' | b'0'
+                ..=b'9' | b't' | b'f' | b'n' | b'e'
+        )
+    ) {
+        return None;
+    }
+
+    let offset = u32::try_from(id_start).ok()?;
+    Some((id, ScannedHeader { offset, generation }))
+}
+
+/// Step backwards over whitespace ending at `end`; at least one whitespace
+/// byte is required (the tokens of a header cannot touch).
+fn skip_whitespace_backwards(buffer: &[u8], end: usize) -> Option<usize> {
+    let mut pos = end;
+    while pos > 0 && is_whitespace(buffer[pos - 1]) {
+        pos -= 1;
+    }
+    (pos < end).then_some(pos)
+}
+
+/// Parse the digit run ending at `end`, returning its start and value.
+fn parse_digits_backwards(buffer: &[u8], end: usize) -> Option<(usize, u64)> {
+    let mut start = end;
+    while start > 0 && buffer[start - 1].is_ascii_digit() {
+        start -= 1;
+    }
+    // At most 10 digits: enough for any u32 id and keeps the value in u64.
+    if start == end || end - start > 10 {
+        return None;
+    }
+    let mut value: u64 = 0;
+    for &byte in &buffer[start..end] {
+        value = value * 10 + u64::from(byte - b'0');
+    }
+    Some((start, value))
+}
+
+/// Parse the dictionary of the object whose header starts at `offset`,
+/// returning it with the buffer position just past the closing `>>`.
+/// Non-dictionary objects return `None` cheaply (first byte check).
+fn parse_header_dict(buffer: &[u8], offset: u32) -> Option<(Dictionary, usize)> {
+    let mut lexer = Lexer {
+        buffer,
+        pos: offset as usize,
+    };
+    lexer.skip_whitespace();
+    lexer.parse_unsigned::<u32>()?;
+    lexer.skip_whitespace();
+    lexer.parse_unsigned::<u16>()?;
+    lexer.skip_whitespace();
+    if !lexer.try_keyword(b"obj") {
+        return None;
+    }
+    lexer.skip_whitespace();
+    if lexer.peek() != Some(b'<') {
+        return None;
+    }
+    match lexer.parse_object(0)? {
+        Object::Dictionary(dict) => Some((dict, lexer.pos)),
+        _ => None,
+    }
+}
+
+/// Recover a trailer dictionary: the last parseable `trailer` dict carrying a
+/// /Root reference wins; xref-stream files (no `trailer` keyword) fall back
+/// to the last recovered /Type /XRef dictionary, which doubles as a trailer.
+fn recover_trailer_dict(buffer: &[u8], xref_trailers: &[(u32, Dictionary)]) -> Option<Dictionary> {
+    let mut best: Option<Dictionary> = None;
+    for pos in memmem::find_iter(buffer, b"trailer") {
+        if pos > 0 {
+            let prev = buffer[pos - 1];
+            if !is_whitespace(prev) && !is_delimiter(prev) {
+                continue;
+            }
+        }
+        let mut lexer = Lexer { buffer, pos };
+        if !lexer.try_keyword(b"trailer") {
+            continue;
+        }
+        let Some(Object::Dictionary(dict)) = lexer.parse_object(0) else {
+            continue;
+        };
+        if dict
+            .get(b"Root")
+            .map(|root| root.as_reference().is_ok())
+            .unwrap_or(false)
+        {
+            best = Some(dict);
+        }
+    }
+    best.or_else(|| {
+        xref_trailers
+            .iter()
+            .filter(|(_, dict)| {
+                dict.get(b"Root")
+                    .map(|root| root.as_reference().is_ok())
+                    .unwrap_or(false)
+            })
+            .max_by_key(|(offset, _)| *offset)
+            .map(|(_, dict)| dict.clone())
+    })
+}
+
+/// An object whose recovered header dictionary is `/Type /ObjStm`.
+struct ObjStmCandidate {
+    container: u32,
+    dict: Dictionary,
+    /// Buffer position just past the dictionary's closing `>>`.
+    dict_end: usize,
+}
+
+/// Register `XrefEntry::Compressed` entries for the members of an object
+/// stream. A top-level `N G obj` header always beats membership here: it is
+/// direct evidence in the file, and incremental updates that replace a
+/// compressed object append exactly such a header.
+///
+/// When `member_catalogs` is given (no root candidate was found elsewhere),
+/// each member's dictionary is also inspected so a catalog compressed into an
+/// object stream can still serve as the root.
+fn expand_object_stream(
+    buffer: &[u8],
+    headers: &BTreeMap<u32, ScannedHeader>,
+    candidate: &ObjStmCandidate,
+    entries: &mut BTreeMap<u32, XrefEntry>,
+    mut member_catalogs: Option<&mut Vec<ObjectId>>,
+) -> Option<()> {
+    let count = usize::try_from(candidate.dict.get(b"N").ok()?.as_i64().ok()?).ok()?;
+    let content = stream_content(buffer, candidate, headers)?;
+    let stream = lopdf::Stream::new(candidate.dict.clone(), content.to_vec());
+    // An undecodable stream contributes nothing; an unfiltered one is its own
+    // decoded content.
+    let decoded = stream
+        .decompressed_content()
+        .unwrap_or_else(|_| content.to_vec());
+    let first = candidate
+        .dict
+        .get(b"First")
+        .ok()
+        .and_then(|first| first.as_i64().ok())
+        .and_then(|first| usize::try_from(first).ok());
+
+    let mut lexer = Lexer {
+        buffer: &decoded,
+        pos: 0,
+    };
+    for index in 0..count.min(MAX_OBJSTM_ENTRIES) {
+        lexer.skip_whitespace();
+        let id = lexer.parse_unsigned::<u32>()?;
+        lexer.skip_whitespace();
+        let member_offset = lexer.parse_unsigned::<u64>()?;
+        if id == 0 {
+            continue;
+        }
+        entries.entry(id).or_insert(XrefEntry::Compressed {
+            container: candidate.container,
+            index: index as u16,
+        });
+        if let (Some(catalogs), Some(first)) = (member_catalogs.as_deref_mut(), first) {
+            let start = first.checked_add(member_offset as usize);
+            if let Some(start) = start.filter(|start| *start < decoded.len()) {
+                let mut member = Lexer {
+                    buffer: &decoded,
+                    pos: start,
+                };
+                if let Some(Object::Dictionary(dict)) = member.parse_object(0) {
+                    // Compressed objects always have generation 0.
+                    if dict.has_type(b"Catalog") {
+                        catalogs.push((id, 0));
+                    }
+                }
+            }
+        }
+    }
+    Some(())
+}
+
+/// Slice the raw stream content following an object's dictionary, but only
+/// when the declared /Length (direct, or indirect through the recovered
+/// headers) verifies — `endstream` must sit right behind it. A lied-about
+/// length makes the container unreadable for the runtime reader too (lopdf
+/// trusts /Length), so registering its members would trade "missing object,
+/// tolerated as null" for a hard error mid-copy; skipping the container is
+/// the better degradation.
+fn stream_content<'a>(
+    buffer: &'a [u8],
+    candidate: &ObjStmCandidate,
+    headers: &BTreeMap<u32, ScannedHeader>,
+) -> Option<&'a [u8]> {
+    let mut lexer = Lexer {
+        buffer,
+        pos: candidate.dict_end,
+    };
+    lexer.skip_whitespace();
+    if !lexer.try_keyword(b"stream") {
+        return None;
+    }
+    lexer.consume_stream_eol()?;
+    let start = lexer.pos;
+
+    let length = resolve_stream_length(&candidate.dict, buffer, headers)?;
+    let end = start
+        .checked_add(length)
+        .filter(|end| *end <= buffer.len())?;
+    let mut tail = Lexer { buffer, pos: end };
+    tail.skip_whitespace();
+    tail.try_keyword(b"endstream").then(|| &buffer[start..end])
+}
+
+/// Resolve a stream dictionary's /Length: a direct integer, or an indirect
+/// reference resolved through the recovered headers.
+fn resolve_stream_length(
+    dict: &Dictionary,
+    buffer: &[u8],
+    headers: &BTreeMap<u32, ScannedHeader>,
+) -> Option<usize> {
+    match dict.get(b"Length").ok()? {
+        Object::Integer(length) => usize::try_from(*length).ok(),
+        Object::Reference((id, generation)) => {
+            let header = headers.get(id)?;
+            if header.generation != *generation {
+                return None;
+            }
+            let mut lexer = Lexer {
+                buffer,
+                pos: header.offset as usize,
+            };
+            lexer.skip_whitespace();
+            lexer.parse_unsigned::<u32>()?;
+            lexer.skip_whitespace();
+            lexer.parse_unsigned::<u16>()?;
+            lexer.skip_whitespace();
+            if !lexer.try_keyword(b"obj") {
+                return None;
+            }
+            match lexer.parse_object(0)? {
+                Object::Integer(length) => usize::try_from(length).ok(),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Version from the `%PDF-` header, tolerating leading junk; a mangled header
+/// falls back to 1.4, which only affects the version stamp of rewrites.
+fn recover_version(buffer: &[u8]) -> String {
+    let window = &buffer[..buffer.len().min(1024)];
+    memmem::find(window, b"%PDF-")
+        .and_then(|pos| parse_version(&buffer[pos..]))
+        .unwrap_or_else(|| "1.4".to_string())
+}
+
+/// Check that `root` resolves through the recovered table to a dictionary
+/// that looks like a catalog. The document moves through the `Reader` and
+/// back so the caller can keep it without cloning the reference table.
+fn root_resolves_to_catalog(buffer: &[u8], document: Document, root: ObjectId) -> (Document, bool) {
+    let reader = Reader {
+        buffer,
+        document,
+        encryption_state: None,
+        raw_objects: BTreeMap::new(),
+        password: None,
+        strict: false,
+    };
+    let is_catalog = reader
+        .get_object(root, &mut HashSet::new())
+        .ok()
+        .and_then(|object| {
+            object
+                .as_dict()
+                .map(|dict| dict.has_type(b"Catalog") || dict.has(b"Pages"))
+                .ok()
+        })
+        .unwrap_or(false);
+    (reader.document, is_catalog)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scanned_ids(buffer: &[u8]) -> Vec<u32> {
+        scan_object_headers(buffer).into_keys().collect()
+    }
+
+    #[test]
+    fn header_scan_finds_headers_across_whitespace_styles() {
+        let headers = scan_object_headers(
+            b"%PDF-1.4\n1 0 obj\n<< >>\nendobj\r\n2 0 obj<< >>endobj\n3\t0\tobj\n[1 2]\nendobj\n",
+        );
+        assert_eq!(headers.keys().copied().collect::<Vec<_>>(), vec![1, 2, 3]);
+        assert_eq!(headers[&1].offset, 9);
+        assert_eq!(headers[&1].generation, 0);
+    }
+
+    #[test]
+    fn header_scan_rejects_lookalikes() {
+        // Digits glued to a name are not an object number.
+        assert!(scanned_ids(b"/F12 0 obj << >>").is_empty());
+        // `obj` followed by a delimiter that cannot start an object is
+        // string/stream payload, not a header.
+        assert!(scanned_ids(b"(see 1 0 obj)").is_empty());
+        // Generation beyond u16 is implausible.
+        assert!(scanned_ids(b" 1 99999999 obj << >>").is_empty());
+        // Object number 0 is always free.
+        assert!(scanned_ids(b" 0 0 obj << >>").is_empty());
+        // Missing whitespace between the tokens is not a header.
+        assert!(scanned_ids(b" 10obj << >>").is_empty());
+    }
+
+    #[test]
+    fn header_scan_later_duplicate_wins() {
+        let buffer = b" 5 0 obj\n<< /A 1 >>\nendobj\n 5 0 obj\n<< /A 2 >>\nendobj\n";
+        let headers = scan_object_headers(buffer);
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[&5].offset, 28);
+    }
+
+    /// A three-object document whose xref/trailer bytes are replaced by
+    /// `tail`. Offsets shift with the length of `prefix`, which the scan must
+    /// not care about.
+    fn damaged_pdf(prefix: &[u8], tail: &[u8]) -> Vec<u8> {
+        let mut pdf = prefix.to_vec();
+        pdf.extend_from_slice(b"%PDF-1.4\n");
+        pdf.extend_from_slice(b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+        pdf.extend_from_slice(b"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+        pdf.extend_from_slice(
+            b"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>\nendobj\n",
+        );
+        pdf.extend_from_slice(tail);
+        pdf
+    }
+
+    #[test]
+    fn reconstructs_without_any_trailer() {
+        let pdf = damaged_pdf(b"", b"xref\ngarbage that is not a table\n%%EOF\n");
+        let document = reconstruct_document(&pdf).expect("catalog fallback should recover");
+        assert_eq!(
+            document
+                .trailer
+                .get(b"Root")
+                .unwrap()
+                .as_reference()
+                .unwrap(),
+            (1, 0)
+        );
+        assert_eq!(document.trailer.get(b"Size").unwrap().as_i64().unwrap(), 4);
+        for id in 1..=3u32 {
+            assert!(
+                matches!(
+                    document.reference_table.get(id),
+                    Some(XrefEntry::Normal { .. })
+                ),
+                "object {id} missing from the recovered table"
+            );
+        }
+    }
+
+    #[test]
+    fn reconstructs_with_junk_before_header() {
+        // Mail-mangled files carry junk before `%PDF-`, shifting every stored
+        // offset; recovered offsets come from real positions, so the page
+        // walk must still resolve.
+        let pdf = damaged_pdf(b"From mail-gateway garbage line\n", b"%%EOF\n");
+        let document = reconstruct_document(&pdf).expect("junk prefix should not matter");
+        let Some(XrefEntry::Normal { offset, .. }) = document.reference_table.get(1) else {
+            panic!("object 1 missing");
+        };
+        assert_eq!(&pdf[*offset as usize..*offset as usize + 7], b"1 0 obj");
+    }
+
+    #[test]
+    fn trailer_root_wins_over_catalog_fallback() {
+        // A parseable trailer names the root even when its /Size is junk and
+        // startxref points nowhere.
+        let pdf = damaged_pdf(
+            b"",
+            b"trailer\n<< /Root 1 0 R /Size -7 >>\nstartxref\n999999\n%%EOF\n",
+        );
+        let document = reconstruct_document(&pdf).expect("trailer should recover");
+        assert_eq!(
+            document
+                .trailer
+                .get(b"Root")
+                .unwrap()
+                .as_reference()
+                .unwrap(),
+            (1, 0)
+        );
+    }
+
+    #[test]
+    fn refuses_encrypted_and_unrecoverable_buffers() {
+        // Encrypted: the lazy reader cannot decrypt, so repair must refuse.
+        let pdf = damaged_pdf(b"", b"trailer\n<< /Root 1 0 R /Encrypt 9 0 R >>\n%%EOF\n");
+        assert!(reconstruct_document(&pdf).is_none());
+        // No object headers at all.
+        assert!(reconstruct_document(b"not a pdf, no objects here").is_none());
+        // Headers but no catalog and no trailer: nothing to trust as root.
+        assert!(
+            reconstruct_document(b"%PDF-1.4\n1 0 obj\n<< /Type /Font >>\nendobj\n%%EOF\n")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn expands_object_stream_members() {
+        // Catalog (5) and pages (6) live inside an uncompressed object
+        // stream; page 7 is top-level. The trailer is destroyed, so the root
+        // must be found through the recovered compressed entries.
+        let members =
+            b"<< /Type /Catalog /Pages 6 0 R >> << /Type /Pages /Kids [7 0 R] /Count 1 >>";
+        let pairs = "5 0 6 34 ";
+        let first = pairs.len();
+        let content = format!("{pairs}{}", String::from_utf8_lossy(members));
+        let mut pdf = Vec::new();
+        pdf.extend_from_slice(b"%PDF-1.5\n");
+        pdf.extend_from_slice(
+            format!(
+                "4 0 obj\n<< /Type /ObjStm /N 2 /First {first} /Length {} >>\nstream\n{content}\nendstream\nendobj\n",
+                content.len()
+            )
+            .as_bytes(),
+        );
+        pdf.extend_from_slice(
+            b"7 0 obj\n<< /Type /Page /Parent 6 0 R /MediaBox [0 0 10 10] >>\nendobj\n",
+        );
+        pdf.extend_from_slice(b"garbage instead of an xref stream\n%%EOF\n");
+
+        let document = reconstruct_document(&pdf).expect("object stream members should recover");
+        assert_eq!(
+            document
+                .trailer
+                .get(b"Root")
+                .unwrap()
+                .as_reference()
+                .unwrap(),
+            (5, 0)
+        );
+        assert!(matches!(
+            document.reference_table.get(5),
+            Some(XrefEntry::Compressed {
+                container: 4,
+                index: 0
+            })
+        ));
+        assert!(matches!(
+            document.reference_table.get(6),
+            Some(XrefEntry::Compressed {
+                container: 4,
+                index: 1
+            })
+        ));
+        // Top-level headers always beat object-stream membership.
+        assert!(matches!(
+            document.reference_table.get(7),
+            Some(XrefEntry::Normal { .. })
+        ));
+    }
+
+    #[test]
+    fn top_level_header_beats_object_stream_membership() {
+        // Object 6 is both a member of the stream and (later) a top-level
+        // object, as an incremental update would leave it.
+        let members = b"<< /Type /Catalog /Pages 6 0 R >> << /Ignored true >>";
+        let content = format!("5 0 6 34 {}", String::from_utf8_lossy(members));
+        let mut pdf = Vec::new();
+        pdf.extend_from_slice(b"%PDF-1.5\n");
+        pdf.extend_from_slice(
+            format!(
+                "4 0 obj\n<< /Type /ObjStm /N 2 /First 9 /Length {} >>\nstream\n{content}\nendstream\nendobj\n",
+                content.len()
+            )
+            .as_bytes(),
+        );
+        pdf.extend_from_slice(
+            b"6 0 obj\n<< /Type /Pages /Kids [7 0 R] /Count 1 >>\nendobj\n\
+              7 0 obj\n<< /Type /Page /Parent 6 0 R /MediaBox [0 0 10 10] >>\nendobj\n%%EOF\n",
+        );
+
+        let document = reconstruct_document(&pdf).expect("should recover");
+        assert!(matches!(
+            document.reference_table.get(6),
+            Some(XrefEntry::Normal { .. })
+        ));
+    }
+
+    #[test]
+    fn skips_object_streams_whose_length_lies() {
+        // /Length claims 5 bytes, so the runtime reader (which trusts
+        // /Length) could never decode this container. Its members must NOT
+        // be registered — a missing object degrades to null during copies,
+        // while a registered-but-unreadable one would be a hard error.
+        let content = "5 0 6 34 << /Ignored true >> << /Ignored true >>";
+        let mut pdf = Vec::new();
+        pdf.extend_from_slice(b"%PDF-1.5\n");
+        pdf.extend_from_slice(
+            format!(
+                "4 0 obj\n<< /Type /ObjStm /N 2 /First 9 /Length 5 >>\nstream\n{content}\nendstream\nendobj\n"
+            )
+            .as_bytes(),
+        );
+        pdf.extend_from_slice(
+            b"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
+              2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n%%EOF\n",
+        );
+
+        let document = reconstruct_document(&pdf).expect("top-level objects still recover");
+        assert!(
+            document.reference_table.get(5).is_none(),
+            "members of an unreadable container must not be registered"
+        );
+        assert!(matches!(
+            document.reference_table.get(4),
+            Some(XrefEntry::Normal { .. })
+        ));
+        assert_eq!(
+            document
+                .trailer
+                .get(b"Root")
+                .unwrap()
+                .as_reference()
+                .unwrap(),
+            (1, 0)
+        );
+    }
+}

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -90,14 +90,6 @@ pub(crate) fn with_repair_retry<'a, T>(
 /// recoverable objects, or no root that resolves to a catalog — in which case
 /// callers surface their original error.
 pub(crate) fn reconstruct_document(buffer: &[u8]) -> Option<Document> {
-    // Encrypted inputs cannot be repaired: object streams and strings would
-    // come out still encrypted. The token search is conservative (a literal
-    // "/Encrypt" inside page content also refuses), but a false hit only
-    // means keeping today's hard error instead of attempting repair.
-    if memmem::find(buffer, b"/Encrypt").is_some() {
-        return None;
-    }
-
     let headers = scan_object_headers(buffer);
     if headers.is_empty() {
         return None;
@@ -125,7 +117,20 @@ pub(crate) fn reconstruct_document(buffer: &[u8]) -> Option<Document> {
         }
     }
 
-    let trailer_source = recover_trailer_dict(buffer, &xref_trailers);
+    let trailers = recover_trailers(buffer, &xref_trailers);
+    // Encrypted inputs cannot be repaired: object streams and strings would
+    // come out still encrypted. A parsed trailer or xref-stream dictionary
+    // naming /Encrypt is authoritative; when none carries a root (the
+    // lowest-trust catalog-fallback path) a raw byte scan for an
+    // `/Encrypt N G R` entry backstops files whose trailers were destroyed
+    // along with the encryption reference they held.
+    if trailers.saw_encrypt {
+        return None;
+    }
+    if trailers.best.is_none() && contains_encrypt_reference(buffer) {
+        return None;
+    }
+    let trailer_source = trailers.best;
 
     // Root candidates in order of trust: the recovered trailer's /Root
     // (generation normalized to the scanned header when they disagree, since
@@ -334,11 +339,21 @@ fn parse_header_dict(buffer: &[u8], offset: u32) -> Option<(Dictionary, usize)> 
     }
 }
 
-/// Recover a trailer dictionary: the last parseable `trailer` dict carrying a
-/// /Root reference wins; xref-stream files (no `trailer` keyword) fall back
-/// to the last recovered /Type /XRef dictionary, which doubles as a trailer.
-fn recover_trailer_dict(buffer: &[u8], xref_trailers: &[(u32, Dictionary)]) -> Option<Dictionary> {
+/// Everything trailer recovery learns about the file.
+struct RecoveredTrailers {
+    /// The trailer to trust: the last parseable `trailer` dict carrying a
+    /// /Root reference, else the last recovered /Type /XRef dictionary
+    /// (xref-stream files have no `trailer` keyword; their stream dict
+    /// doubles as the trailer).
+    best: Option<Dictionary>,
+    /// True when ANY parseable trailer or xref-stream dictionary named
+    /// /Encrypt — including root-less ones the recovery would not use.
+    saw_encrypt: bool,
+}
+
+fn recover_trailers(buffer: &[u8], xref_trailers: &[(u32, Dictionary)]) -> RecoveredTrailers {
     let mut best: Option<Dictionary> = None;
+    let mut saw_encrypt = false;
     for pos in memmem::find_iter(buffer, b"trailer") {
         if pos > 0 {
             let prev = buffer[pos - 1];
@@ -353,6 +368,7 @@ fn recover_trailer_dict(buffer: &[u8], xref_trailers: &[(u32, Dictionary)]) -> O
         let Some(Object::Dictionary(dict)) = lexer.parse_object(0) else {
             continue;
         };
+        saw_encrypt |= dict.has(b"Encrypt");
         if dict
             .get(b"Root")
             .map(|root| root.as_reference().is_ok())
@@ -361,7 +377,8 @@ fn recover_trailer_dict(buffer: &[u8], xref_trailers: &[(u32, Dictionary)]) -> O
             best = Some(dict);
         }
     }
-    best.or_else(|| {
+    saw_encrypt |= xref_trailers.iter().any(|(_, dict)| dict.has(b"Encrypt"));
+    let best = best.or_else(|| {
         xref_trailers
             .iter()
             .filter(|(_, dict)| {
@@ -371,6 +388,35 @@ fn recover_trailer_dict(buffer: &[u8], xref_trailers: &[(u32, Dictionary)]) -> O
             })
             .max_by_key(|(offset, _)| *offset)
             .map(|(_, dict)| dict.clone())
+    });
+    RecoveredTrailers { best, saw_encrypt }
+}
+
+/// True when the buffer contains what looks like a trailer's encryption
+/// entry: the `/Encrypt` name followed by an `N G R` reference. Requiring the
+/// reference tail keeps prose mentions of "/Encrypt" inside page content from
+/// blocking repair, while still catching encrypted files whose trailer
+/// dictionaries no longer parse.
+fn contains_encrypt_reference(buffer: &[u8]) -> bool {
+    memmem::find_iter(buffer, b"/Encrypt").any(|pos| {
+        let mut lexer = Lexer {
+            buffer,
+            pos: pos + b"/Encrypt".len(),
+        };
+        // The name must end here (`/EncryptMetadata` is a different key).
+        match lexer.peek() {
+            Some(byte) if is_whitespace(byte) || is_delimiter(byte) => {}
+            _ => return false,
+        }
+        (|| {
+            lexer.skip_whitespace();
+            lexer.parse_unsigned::<u32>()?;
+            lexer.skip_whitespace();
+            lexer.parse_unsigned::<u16>()?;
+            lexer.skip_whitespace();
+            lexer.try_keyword(b"R").then_some(())
+        })()
+        .is_some()
     })
 }
 
@@ -429,7 +475,9 @@ fn expand_object_stream(
             index: index as u16,
         });
         if let (Some(catalogs), Some(first)) = (member_catalogs.as_deref_mut(), first) {
-            let start = first.checked_add(member_offset as usize);
+            let start = usize::try_from(member_offset)
+                .ok()
+                .and_then(|offset| first.checked_add(offset));
             if let Some(start) = start.filter(|start| *start < decoded.len()) {
                 let mut member = Lexer {
                     buffer: &decoded,
@@ -667,6 +715,15 @@ mod tests {
         // Encrypted: the lazy reader cannot decrypt, so repair must refuse.
         let pdf = damaged_pdf(b"", b"trailer\n<< /Root 1 0 R /Encrypt 9 0 R >>\n%%EOF\n");
         assert!(reconstruct_document(&pdf).is_none());
+        // A root-less (unusable) trailer naming /Encrypt still proves
+        // encryption and must refuse.
+        let pdf = damaged_pdf(b"", b"trailer\n<< /Encrypt 9 0 R >>\n%%EOF\n");
+        assert!(reconstruct_document(&pdf).is_none());
+        // No parseable trailer at all, but the destroyed one's
+        // `/Encrypt N G R` entry survives in the raw bytes: the byte-scan
+        // backstop on the catalog-fallback path must refuse.
+        let pdf = damaged_pdf(b"", b"trailer garbage /Encrypt 9 0 R garbage\n%%EOF\n");
+        assert!(reconstruct_document(&pdf).is_none());
         // No object headers at all.
         assert!(reconstruct_document(b"not a pdf, no objects here").is_none());
         // Headers but no catalog and no trailer: nothing to trust as root.
@@ -674,6 +731,34 @@ mod tests {
             reconstruct_document(b"%PDF-1.4\n1 0 obj\n<< /Type /Font >>\nendobj\n%%EOF\n")
                 .is_none()
         );
+    }
+
+    #[test]
+    fn prose_encrypt_mentions_do_not_block_repair() {
+        // "/Encrypt" appearing as page content (here: inside a string object)
+        // is not an encryption entry: no reference tail follows, and the
+        // recovered trailer is authoritative about the file being plain.
+        let mut pdf = damaged_pdf(b"", b"");
+        pdf.extend_from_slice(b"4 0 obj\n(how /Encrypt works in PDF)\nendobj\n");
+        pdf.extend_from_slice(b"trailer\n<< /Root 1 0 R >>\nstartxref\n999999\n%%EOF\n");
+        assert!(
+            reconstruct_document(&pdf).is_some(),
+            "a prose /Encrypt mention must not block repair"
+        );
+
+        // Same file without any recoverable trailer: the byte-scan backstop
+        // runs, but must still not match a name lacking the reference tail.
+        let mut pdf = damaged_pdf(b"", b"");
+        pdf.extend_from_slice(b"4 0 obj\n(how /Encrypt works in PDF)\nendobj\n%%EOF\n");
+        assert!(
+            reconstruct_document(&pdf).is_some(),
+            "prose /Encrypt without an N G R tail must not trip the backstop"
+        );
+
+        // /EncryptMetadata is a different key and must not match either.
+        let mut pdf = damaged_pdf(b"", b"");
+        pdf.extend_from_slice(b"4 0 obj\n<< /EncryptMetadata 5 0 R >>\nendobj\n%%EOF\n");
+        assert!(reconstruct_document(&pdf).is_some());
     }
 
     #[test]

--- a/src/split.rs
+++ b/src/split.rs
@@ -8,9 +8,9 @@ use rayon::prelude::*;
 
 use crate::{
     copy::{copy_pages_with_options, resolve_page_ids, CopyOptions, ObjectSource},
-    lazy::PdfSource,
     load::{load_document, map_file},
     range::{PageRangeError, PageRangeGroup},
+    repair::with_repair_retry,
     split_template::{SinglePageTemplate, WriteGate},
     PdfOpsError, Result,
 };
@@ -54,22 +54,82 @@ pub fn split_with_password(
         // Every bounded output is treated as a subset (a prefix walk cannot
         // prove full coverage), so pruning stays on.
         let mmap = map_file(input)?;
-        let source = PdfSource::open(&mmap, input, password)?;
-        let ordered_pages = source.page_ids_up_to(limit)?;
+        return with_repair_retry(&mmap, input, password, |source| {
+            let ordered_pages = source.page_ids_up_to(limit)?;
+            if ordered_pages.is_empty() {
+                return Err(PdfOpsError::Range(PageRangeError::NoPages));
+            }
+            let pages: BTreeMap<u32, lopdf::ObjectId> = (1u32..).zip(ordered_pages).collect();
+            let resolved_outputs = resolve_split_outputs(outputs, &pages, true)?;
+            reject_duplicate_output_paths(&resolved_outputs)?;
+            run_split_outputs(source, &resolved_outputs)
+        });
+    }
+
+    let source = match load_document(input, password) {
+        Ok(source) => source,
+        // The eager parse failed structurally, or tolerated its way to an
+        // empty page tree. Retry through the lazy source, which can bootstrap
+        // a syntactically-fine xref, reconstruct a damaged one, and
+        // repair-retry offsets that lie (issue #14). Password and I/O errors
+        // keep their meaning and propagate.
+        Err(PdfOpsError::Pdf(_)) | Err(PdfOpsError::Range(PageRangeError::NoPages)) => {
+            return split_via_lazy(input, password, outputs);
+        }
+        Err(err) => return Err(err),
+    };
+    let pages = source.get_pages();
+    // A successful eager parse can still be lossy on damaged files: lopdf
+    // (non-strict) skips objects whose xref offset points at the wrong
+    // object, silently shrinking the page tree. When the declared /Count
+    // disagrees with the walked tree, distrust the eager document and reroute
+    // through the lazy source, whose strict fetches surface the damage and
+    // drive the repair retry.
+    if eager_page_tree_is_suspect(&source, pages.len()) {
+        return split_via_lazy(input, password, outputs);
+    }
+    let resolved_outputs = resolve_split_outputs(outputs, &pages, false)?;
+    reject_duplicate_output_paths(&resolved_outputs)?;
+    run_split_outputs(&source, &resolved_outputs)
+}
+
+/// Unbounded split through the lazy source: the fallback when the eager
+/// parse fails or cannot be trusted. Fetch errors that prove the xref lies
+/// re-run the split against a reconstructed table.
+fn split_via_lazy(input: &Path, password: Option<&str>, outputs: &[SplitOutput]) -> Result<()> {
+    let mmap = map_file(input)?;
+    with_repair_retry(&mmap, input, password, |source| {
+        let ordered_pages = source.page_ids()?;
         if ordered_pages.is_empty() {
             return Err(PdfOpsError::Range(PageRangeError::NoPages));
         }
         let pages: BTreeMap<u32, lopdf::ObjectId> = (1u32..).zip(ordered_pages).collect();
-        let resolved_outputs = resolve_split_outputs(outputs, &pages, true)?;
+        let resolved_outputs = resolve_split_outputs(outputs, &pages, false)?;
         reject_duplicate_output_paths(&resolved_outputs)?;
-        return run_split_outputs(&source, &resolved_outputs);
-    }
+        run_split_outputs(source, &resolved_outputs)
+    })
+}
 
-    let source = load_document(input, password)?;
-    let pages = source.get_pages();
-    let resolved_outputs = resolve_split_outputs(outputs, &pages, false)?;
-    reject_duplicate_output_paths(&resolved_outputs)?;
-    run_split_outputs(&source, &resolved_outputs)
+/// True when the root `/Pages` `/Count` is a direct integer that disagrees
+/// with the pages the eager document actually enumerates — the signature of
+/// lopdf's non-strict loader having skipped damaged objects. Documents
+/// without a readable direct /Count cannot be judged and are trusted as-is.
+fn eager_page_tree_is_suspect(document: &Document, walked: usize) -> bool {
+    let declared = (|| {
+        document
+            .catalog()
+            .ok()?
+            .get(b"Pages")
+            .ok()?
+            .as_reference()
+            .ok()
+            .and_then(|id| document.get_dictionary(id).ok())?
+            .get(b"Count")
+            .ok()?
+            .as_i64()
+            .ok()
+    })();
+    declared.is_some_and(|count| count != walked as i64)
 }
 
 fn resolve_split_outputs(
@@ -153,41 +213,42 @@ pub fn split_pages_with_options(
     }
 
     let mmap = map_file(input)?;
-    let source = PdfSource::open(&mmap, input, options.password.as_deref())?;
-    let pages = source.page_ids()?;
-    let page_count = pages.len();
-    if page_count == 0 {
-        return Err(PdfOpsError::Range(PageRangeError::NoPages));
-    }
-    let chunk_count = page_count.div_ceil(options.pages_per_file);
-    let width = chunk_count.to_string().len();
-    let resolved_outputs = pages
-        .chunks(options.pages_per_file)
-        .enumerate()
-        .map(|(chunk_index, chunk)| {
-            Ok(ResolvedSplitOutput {
-                path: render_output_pattern(output_pattern, chunk_index + 1, width)?,
-                page_ids: chunk.to_vec(),
-                // split-pages always prunes: emitting page subsets is its
-                // whole purpose, and pruning single-page outputs (including
-                // the one-page-document edge) is long-standing behavior.
-                prune_resources: true,
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    // Fast path (single-page outputs only — the template writer emits exactly
-    // one page per file): serialize the objects shared by every page once,
-    // then emit only page-specific objects per output. Falls back to the
-    // generic per-output Document path whenever the template cannot be
-    // prepared.
-    if options.pages_per_file == 1 {
-        if let Some(template) = SinglePageTemplate::prepare(&source, &pages) {
-            return run_template_outputs(&source, &template, &resolved_outputs);
+    with_repair_retry(&mmap, input, options.password.as_deref(), |source| {
+        let pages = source.page_ids()?;
+        let page_count = pages.len();
+        if page_count == 0 {
+            return Err(PdfOpsError::Range(PageRangeError::NoPages));
         }
-    }
+        let chunk_count = page_count.div_ceil(options.pages_per_file);
+        let width = chunk_count.to_string().len();
+        let resolved_outputs = pages
+            .chunks(options.pages_per_file)
+            .enumerate()
+            .map(|(chunk_index, chunk)| {
+                Ok(ResolvedSplitOutput {
+                    path: render_output_pattern(output_pattern, chunk_index + 1, width)?,
+                    page_ids: chunk.to_vec(),
+                    // split-pages always prunes: emitting page subsets is its
+                    // whole purpose, and pruning single-page outputs (including
+                    // the one-page-document edge) is long-standing behavior.
+                    prune_resources: true,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
 
-    run_split_outputs(&source, &resolved_outputs)
+        // Fast path (single-page outputs only — the template writer emits
+        // exactly one page per file): serialize the objects shared by every
+        // page once, then emit only page-specific objects per output. Falls
+        // back to the generic per-output Document path whenever the template
+        // cannot be prepared.
+        if options.pages_per_file == 1 {
+            if let Some(template) = SinglePageTemplate::prepare(source, &pages) {
+                return run_template_outputs(source, &template, &resolved_outputs);
+            }
+        }
+
+        run_split_outputs(source, &resolved_outputs)
+    })
 }
 
 /// Concurrent output-file writes allowed during a template split; see

--- a/src/xrefboot.rs
+++ b/src/xrefboot.rs
@@ -117,7 +117,7 @@ pub(crate) fn bootstrap_document(buffer: &[u8]) -> Option<Document> {
     Some(document)
 }
 
-fn parse_version(buffer: &[u8]) -> Option<String> {
+pub(crate) fn parse_version(buffer: &[u8]) -> Option<String> {
     let rest = buffer.strip_prefix(b"%PDF-")?;
     let len = rest
         .iter()
@@ -422,13 +422,15 @@ fn read_big_endian(bytes: &[u8]) -> u64 {
 /// Minimal hand-rolled tokenizer/object parser: just enough of the PDF object
 /// grammar for trailer dictionaries and xref-stream headers (names, numbers,
 /// booleans, null, references, arrays, dictionaries, hex/literal strings).
-struct Lexer<'a> {
-    buffer: &'a [u8],
-    pos: usize,
+/// Shared with `crate::repair`, which re-parses recovered object headers and
+/// trailer candidates with the same grammar.
+pub(crate) struct Lexer<'a> {
+    pub(crate) buffer: &'a [u8],
+    pub(crate) pos: usize,
 }
 
 impl<'a> Lexer<'a> {
-    fn peek(&self) -> Option<u8> {
+    pub(crate) fn peek(&self) -> Option<u8> {
         self.buffer.get(self.pos).copied()
     }
 
@@ -446,7 +448,7 @@ impl<'a> Lexer<'a> {
         self.buffer.len() - self.pos
     }
 
-    fn take(&mut self, len: usize) -> Option<&'a [u8]> {
+    pub(crate) fn take(&mut self, len: usize) -> Option<&'a [u8]> {
         let end = self.pos.checked_add(len)?;
         if end > self.buffer.len() {
             return None;
@@ -456,7 +458,7 @@ impl<'a> Lexer<'a> {
         Some(slice)
     }
 
-    fn skip_whitespace(&mut self) {
+    pub(crate) fn skip_whitespace(&mut self) {
         while let Some(byte) = self.peek() {
             if is_whitespace(byte) {
                 self.pos += 1;
@@ -476,7 +478,7 @@ impl<'a> Lexer<'a> {
 
     /// Consume `keyword` if it is present at the cursor and ends at a token
     /// boundary (whitespace, delimiter, or end of input).
-    fn try_keyword(&mut self, keyword: &[u8]) -> bool {
+    pub(crate) fn try_keyword(&mut self, keyword: &[u8]) -> bool {
         let end = self.pos + keyword.len();
         if self.buffer.len() < end || &self.buffer[self.pos..end] != keyword {
             return false;
@@ -490,7 +492,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn parse_unsigned<T: TryFrom<u64>>(&mut self) -> Option<T> {
+    pub(crate) fn parse_unsigned<T: TryFrom<u64>>(&mut self) -> Option<T> {
         let start = self.pos;
         let mut value: u64 = 0;
         while let Some(byte) = self.peek() {
@@ -508,7 +510,7 @@ impl<'a> Lexer<'a> {
 
     /// The EOL that separates the `stream` keyword from the stream data:
     /// CRLF or LF per spec, plus lone CR for robustness.
-    fn consume_stream_eol(&mut self) -> Option<()> {
+    pub(crate) fn consume_stream_eol(&mut self) -> Option<()> {
         match self.next_byte()? {
             b'\n' => Some(()),
             b'\r' => {
@@ -521,7 +523,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn parse_object(&mut self, depth: usize) -> Option<Object> {
+    pub(crate) fn parse_object(&mut self, depth: usize) -> Option<Object> {
         if depth > MAX_OBJECT_DEPTH {
             return None;
         }
@@ -738,11 +740,11 @@ impl<'a> Lexer<'a> {
     }
 }
 
-fn is_whitespace(byte: u8) -> bool {
+pub(crate) fn is_whitespace(byte: u8) -> bool {
     matches!(byte, b'\0' | b'\t' | b'\n' | b'\x0c' | b'\r' | b' ')
 }
 
-fn is_delimiter(byte: u8) -> bool {
+pub(crate) fn is_delimiter(byte: u8) -> bool {
     matches!(
         byte,
         b'(' | b')' | b'<' | b'>' | b'[' | b']' | b'{' | b'}' | b'/' | b'%'

--- a/tests/repair.rs
+++ b/tests/repair.rs
@@ -1,0 +1,278 @@
+//! Best-effort repair of damaged cross-reference data (issue #14).
+//!
+//! Fixtures are healthy files from `tests/fixtures` damaged in-memory: the
+//! mutations model the two real-world classes — destroyed xref/trailer data
+//! (load-time reconstruction) and syntactically-fine tables whose offsets lie
+//! (fetch-time repair retry).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use lopdf::Document;
+use pdq::{merge_with_options, page_count, split_pages, MergeInput, MergeOptions, PageRangeGroup};
+use predicates::prelude::*;
+use tempfile::{tempdir, TempDir};
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn pdq() -> Command {
+    Command::cargo_bin("pdq").unwrap()
+}
+
+fn assert_page_count(path: &Path, expected: usize) {
+    let document = Document::load(path)
+        .unwrap_or_else(|err| panic!("failed to load {}: {err}", path.display()));
+    assert_eq!(
+        document.get_pages().len(),
+        expected,
+        "unexpected page count for {}",
+        path.display()
+    );
+}
+
+fn write_damaged(temp: &TempDir, name: &str, bytes: &[u8]) -> PathBuf {
+    let path = temp.path().join(name);
+    fs::write(&path, bytes).unwrap();
+    path
+}
+
+/// Cut everything from the last occurrence of `pattern` onwards.
+fn truncate_at(bytes: &[u8], pattern: &[u8]) -> Vec<u8> {
+    let pos = bytes
+        .windows(pattern.len())
+        .rposition(|window| window == pattern)
+        .unwrap_or_else(|| panic!("pattern {:?} not found", String::from_utf8_lossy(pattern)));
+    bytes[..pos].to_vec()
+}
+
+/// Swap the 10-digit offsets of the first two in-use entries of the last
+/// classic xref table, so both entries point at the wrong object while the
+/// table stays perfectly parseable — the fetch-time damage class.
+fn swap_first_two_xref_offsets(bytes: &[u8]) -> Vec<u8> {
+    // `\nxref` cannot match inside `startxref`, unlike a bare `xref`.
+    let table = bytes
+        .windows(5)
+        .rposition(|window| window == b"\nxref")
+        .expect("classic xref table not found");
+    let mut positions = Vec::new();
+    let mut pos = table;
+    while positions.len() < 2 && pos + 20 <= bytes.len() {
+        // An in-use entry line: "NNNNNNNNNN GGGGG n ".
+        if bytes[pos..].starts_with(b"0")
+            && bytes[pos..pos + 10].iter().all(u8::is_ascii_digit)
+            && &bytes[pos + 10..pos + 11] == b" "
+            && &bytes[pos + 16..pos + 18] == b" n"
+        {
+            positions.push(pos);
+            pos += 20;
+        } else {
+            pos += 1;
+        }
+    }
+    let [first, second] = positions[..] else {
+        panic!("fewer than two in-use xref entries found");
+    };
+    let mut damaged = bytes.to_vec();
+    let (a, b) = (
+        bytes[first..first + 10].to_vec(),
+        bytes[second..second + 10].to_vec(),
+    );
+    damaged[first..first + 10].copy_from_slice(&b);
+    damaged[second..second + 10].copy_from_slice(&a);
+    damaged
+}
+
+#[test]
+fn destroyed_classic_xref_reconstructs_on_load() {
+    // Cutting at the `xref` keyword removes the table, trailer, and
+    // startxref: only the raw object scan can load this, and the root must
+    // come from the /Type /Catalog fallback.
+    let temp = tempdir().unwrap();
+    let bytes = fs::read(fixture("11-pages.pdf")).unwrap();
+    let damaged = write_damaged(&temp, "truncated.pdf", &truncate_at(&bytes, b"xref"));
+
+    assert_eq!(page_count(&damaged).unwrap(), 11);
+
+    let pattern = temp.path().join("page-%d.pdf");
+    split_pages(&damaged, pattern.to_str().unwrap()).unwrap();
+    for page in 1..=11 {
+        assert_page_count(&temp.path().join(format!("page-{page:02}.pdf")), 1);
+    }
+}
+
+#[test]
+fn destroyed_xref_stream_reconstructs_on_load() {
+    // The object-stream fixture keeps its /Type /XRef stream object but
+    // loses `startxref`: reconstruction must expand the object stream's
+    // members and recover the trailer from the xref stream's dictionary.
+    let temp = tempdir().unwrap();
+    let bytes = fs::read(fixture("11-pages-objstm.pdf")).unwrap();
+    let damaged = write_damaged(
+        &temp,
+        "truncated-objstm.pdf",
+        &truncate_at(&bytes, b"startxref"),
+    );
+
+    assert_eq!(page_count(&damaged).unwrap(), 11);
+
+    let pattern = temp.path().join("page-%d.pdf");
+    split_pages(&damaged, pattern.to_str().unwrap()).unwrap();
+    for page in 1..=11 {
+        assert_page_count(&temp.path().join(format!("page-{page:02}.pdf")), 1);
+    }
+}
+
+#[test]
+fn lying_xref_offsets_repair_at_fetch_time() {
+    // The table parses fine (the bootstrap accepts it) but its first two
+    // entries point at each other's objects, so the first fetch raises an
+    // object-id mismatch and the operation retries against a reconstructed
+    // table.
+    let temp = tempdir().unwrap();
+    let bytes = fs::read(fixture("11-pages.pdf")).unwrap();
+    let damaged = write_damaged(&temp, "lying.pdf", &swap_first_two_xref_offsets(&bytes));
+
+    assert_eq!(page_count(&damaged).unwrap(), 11);
+
+    let pattern = temp.path().join("page-%d.pdf");
+    split_pages(&damaged, pattern.to_str().unwrap()).unwrap();
+    for page in 1..=11 {
+        assert_page_count(&temp.path().join(format!("page-{page:02}.pdf")), 1);
+    }
+}
+
+#[test]
+fn merge_repairs_damaged_inputs_alongside_healthy_ones() {
+    let temp = tempdir().unwrap();
+    let bytes = fs::read(fixture("11-pages.pdf")).unwrap();
+    let truncated = write_damaged(&temp, "truncated.pdf", &truncate_at(&bytes, b"xref"));
+    let lying = write_damaged(&temp, "lying.pdf", &swap_first_two_xref_offsets(&bytes));
+    let output = temp.path().join("merged.pdf");
+
+    // Whole-file merge takes the streaming path; the lying input aborts the
+    // first attempt and the merge restarts with it force-repaired.
+    merge_with_options(
+        &[
+            MergeInput::all(&truncated),
+            MergeInput::all(&lying),
+            MergeInput::all(fixture("11-pages.pdf")),
+        ],
+        &output,
+        MergeOptions::default(),
+    )
+    .unwrap();
+    assert_page_count(&output, 33);
+
+    // Ranged merge takes the eager per-input copy path and its own restart
+    // loop.
+    let ranged_output = temp.path().join("merged-ranged.pdf");
+    merge_with_options(
+        &[
+            MergeInput {
+                path: lying.clone(),
+                ranges: vec![PageRangeGroup::parse("1-3").unwrap()],
+            },
+            MergeInput::all(fixture("11-pages.pdf")),
+        ],
+        &ranged_output,
+        MergeOptions::default(),
+    )
+    .unwrap();
+    assert_page_count(&ranged_output, 14);
+}
+
+#[test]
+fn repaired_single_input_merge_is_rewritten_not_byte_copied() {
+    // `merge` with one whole input normally byte-copies, but a repaired
+    // source must be rewritten so the output carries a valid xref instead of
+    // a verbatim copy of the damage.
+    let temp = tempdir().unwrap();
+    let bytes = fs::read(fixture("11-pages.pdf")).unwrap();
+    let damaged_bytes = truncate_at(&bytes, b"xref");
+    let damaged = write_damaged(&temp, "truncated.pdf", &damaged_bytes);
+    let output = temp.path().join("preserved.pdf");
+
+    merge_with_options(
+        &[MergeInput::all(&damaged)],
+        &output,
+        MergeOptions {
+            preserve_whole_single_input: true,
+            ..MergeOptions::default()
+        },
+    )
+    .unwrap();
+
+    assert_ne!(
+        fs::read(&output).unwrap(),
+        damaged_bytes,
+        "damaged input must not be byte-copied"
+    );
+    assert_page_count(&output, 11);
+}
+
+#[test]
+fn encrypted_damaged_input_is_not_repaired() {
+    // Repair cannot decrypt, so a damaged encrypted file must keep a hard
+    // error instead of producing garbage output.
+    let temp = tempdir().unwrap();
+    let bytes = fs::read(fixture("user-password.pdf")).unwrap();
+    let damaged = write_damaged(&temp, "encrypted.pdf", &truncate_at(&bytes, b"startxref"));
+
+    assert!(page_count(&damaged).is_err());
+    let pattern = temp.path().join("page-%d.pdf");
+    assert!(split_pages(&damaged, pattern.to_str().unwrap()).is_err());
+}
+
+#[test]
+fn unrepairable_damage_reports_damaged_xref() {
+    // No recoverable objects at all: the error must name the damaged xref
+    // (issue #14's acceptance criterion) instead of lopdf's generic message.
+    let temp = tempdir().unwrap();
+    let damaged = write_damaged(
+        &temp,
+        "hopeless.pdf",
+        b"%PDF-1.4\nthis file has no objects and no xref\n%%EOF\n",
+    );
+
+    let err = page_count(&damaged).unwrap_err().to_string();
+    assert!(
+        err.contains("damaged cross-reference"),
+        "error should name the damaged xref, got: {err}"
+    );
+}
+
+#[test]
+fn damaged_input_cli_warns_on_stderr_and_succeeds() {
+    let temp = tempdir().unwrap();
+    let bytes = fs::read(fixture("11-pages.pdf")).unwrap();
+    let damaged = write_damaged(&temp, "truncated.pdf", &truncate_at(&bytes, b"xref"));
+
+    pdq()
+        .arg("page-count")
+        .arg(&damaged)
+        .assert()
+        .success()
+        .stdout("11\n")
+        .stderr(predicate::str::contains("damaged cross-reference data"));
+}
+
+#[test]
+fn healthy_inputs_never_touch_the_repair_path() {
+    // The repair warning doubles as the observable marker that the scanner
+    // ran: healthy fixtures must produce silent, warning-free runs.
+    for name in ["11-pages.pdf", "11-pages-objstm.pdf", "owner-only.pdf"] {
+        pdq()
+            .arg("page-count")
+            .arg(fixture(name))
+            .assert()
+            .success()
+            .stdout("11\n")
+            .stderr("");
+    }
+}


### PR DESCRIPTION
Closes #14 — the scope decision lands as: **damaged cross-reference data is in scope**, implemented as a strict last resort so correctly-formed files never pay for it.

## Design

The damage check is free because it *is* the existing parse failing — there is no up-front validation pass. `PdfSource::open` keeps its ladder and gains one rung:

```
tier 0: xrefboot bootstrap          (unchanged, healthy fast path)
tier 1: full lopdf parse            (unchanged fallback)
tier 2: repair::reconstruct_document  NEW — only after tier 1 errors
```

The scanner (`src/repair.rs`) sweeps the raw buffer for `N G obj` headers (later duplicates win, approximating incremental updates), recovers the trailer (classic `trailer` keyword → `/Type /XRef` stream dict → last `/Type /Catalog` object, including catalogs compressed inside object streams), expands object-stream members into `Compressed` entries, and validates that the chosen root actually resolves to a catalog. Its output is the **same metadata-only `Document`** that `xrefboot` produces, wrapped in the same `LazyPdf` — there is no separate repaired pipeline; downstream count/copy/split/merge/write behavior is identical by construction. Offsets are self-computed from real byte positions, so junk before `%PDF-` and truncated tails cost nothing.

Damage that only shows at **fetch time** (xref parses fine but offsets lie → `ObjectIdMismatch`/`IndirectObject`) triggers an operation-level retry against a wholesale-reconstructed table (qpdf semantics — no mixed tables, no locks on the hot fetch path). `ObjectNotFound` deliberately does **not** trigger repair: dangling references are legal and already tolerated as null. Multi-input merges restart with a per-input force-repair set (bounded by input count).

Guard rails:
- **Byte-copy refusal**: merge's single-input fast path rewrites repaired sources instead of `fs::copy`ing the damage through.
- **Lossy-eager detection**: lopdf's tolerant eager parse silently *skips* objects with lying offsets; the unbounded split path now distrusts an eager tree whose declared `/Count` disagrees with the walk and reroutes through the lazy repairable source (this was producing a 1-of-2-page rewrite for `issue7229.pdf`).
- **Encrypted + damaged stays a hard error** (repair cannot decrypt); unrepairable files now name the damaged xref and point at dedicated repair tools instead of lopdf's generic `invalid file trailer` (issue #14's fallback acceptance criterion).
- Repaired reads warn once on stderr per source open.

## Results

Corpus harness (qpdf ground truth, ~1.8k files): **WARNs 81 → 47, no new FAILs.** Newly recovered beyond the six files in #14: `bad25/26/27/32`, `bad-xref-entry`, `poppler-90-0-fuzzed`, and friends. All six issue files now count *and* split/rewrite with qpdf-validated outputs.

Healthy-file behavior is unchanged: new code sits behind error branches only; the 2642-page benchmark rewrite is byte-identical to main and `PDQ_TIMING` phases on the 200 MB corpus file are within noise. A CLI test asserts healthy fixtures produce warning-free runs.

## Known gaps (pre-existing, out of scope)

- `issue7665.pdf` FAILs qpdf --check after split — identical on main, unrelated to repair (input is clean, repair never runs).
- `issue15150.pdf` has a lied-about *stream length* (a different tolerance gap — qpdf's "recovered stream length"); its split output carries a null content stream, same as main's bootstrap path.
- Object streams whose declared `/Length` lies are skipped rather than length-recovered: the runtime reader trusts `/Length`, so registering their members would turn a tolerable missing-object null into a hard mid-copy error.
