### PR TITLE
fix(filters): support PDF filter abbreviations

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -8,7 +8,7 @@ use std::{
 
 use lopdf::{Dictionary, Document, Object, ObjectId};
 
-use crate::{scan, scan::UsedNames, PdfOpsError, Result};
+use crate::{filter::decode_stream_content, scan, scan::UsedNames, PdfOpsError, Result};
 
 const INHERITABLE_PAGE_ATTRS: [&[u8]; 4] = [b"Resources", b"MediaBox", b"CropBox", b"Rotate"];
 const MAX_COPY_DEPTH: usize = 256;
@@ -468,7 +468,7 @@ impl CopyContext {
         let Some(used) = scan::collect_used_names_from_stream(
             source,
             stream_id,
-            || stream.decompressed_content().ok(),
+            || decode_stream_content(stream).ok(),
             &resources,
             &mut self.dictionary_cache,
             &mut self.used_names_cache,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,0 +1,283 @@
+use lopdf::{Dictionary, Object, ObjectId, Stream};
+
+pub(crate) const FILTER_ABBREVIATIONS: [(&[u8], &[u8]); 7] = [
+    (b"Fl", b"FlateDecode"),
+    (b"AHx", b"ASCIIHexDecode"),
+    (b"A85", b"ASCII85Decode"),
+    (b"LZW", b"LZWDecode"),
+    (b"RL", b"RunLengthDecode"),
+    (b"CCF", b"CCITTFaxDecode"),
+    (b"DCT", b"DCTDecode"),
+];
+
+pub(crate) fn canonical_filter_name(name: &[u8]) -> &[u8] {
+    FILTER_ABBREVIATIONS
+        .iter()
+        .find_map(|(abbreviation, canonical)| (*abbreviation == name).then_some(*canonical))
+        .unwrap_or(name)
+}
+
+pub(crate) fn normalize_stream_filter_names(stream: &mut Stream) -> bool {
+    let Ok(filter) = stream.dict.get_mut(b"Filter") else {
+        return false;
+    };
+    normalize_filter_object(filter)
+}
+
+pub(crate) fn normalize_object_filter_names(object: &mut Object) {
+    if let Ok(stream) = object.as_stream_mut() {
+        normalize_stream_filter_names(stream);
+    }
+}
+
+pub(crate) fn normalize_filter_names_for_lopdf_load(
+    id: ObjectId,
+    object: &mut Object,
+) -> Option<(ObjectId, Object)> {
+    if let Ok(stream) = object.as_stream_mut() {
+        if stream.dict.has_type(b"ObjStm")
+            && stream.dict.has(b"Filter")
+            && decode_stream_in_place(stream).is_ok()
+        {
+            return Some((id, object.clone()));
+        }
+        normalize_stream_filter_names(stream);
+        return Some((id, object.clone()));
+    }
+    normalize_object_filter_names(object);
+    Some((id, object.clone()))
+}
+
+pub(crate) fn decode_stream_content(stream: &Stream) -> lopdf::Result<Vec<u8>> {
+    let Some(filters) = stream_filters(stream) else {
+        return Ok(stream.content.clone());
+    };
+    let decode_params = stream.dict.get(b"DecodeParms").ok();
+    let mut output = stream.content.clone();
+    for (index, filter) in filters.iter().enumerate() {
+        output = decode_filter(filter, &output, decode_params_at(decode_params, index))?;
+    }
+    Ok(output)
+}
+
+pub(crate) fn decode_stream_in_place(stream: &mut Stream) -> lopdf::Result<()> {
+    let content = decode_stream_content(stream)?;
+    stream.set_plain_content(content);
+    Ok(())
+}
+
+fn normalize_filter_object(filter: &mut Object) -> bool {
+    match filter {
+        Object::Name(name) => normalize_filter_name(name),
+        Object::Array(filters) => {
+            let mut changed = false;
+            for filter in filters {
+                changed |= normalize_filter_object(filter);
+            }
+            changed
+        }
+        _ => false,
+    }
+}
+
+fn normalize_filter_name(name: &mut Vec<u8>) -> bool {
+    let canonical = canonical_filter_name(name);
+    if canonical == name.as_slice() {
+        return false;
+    }
+    *name = canonical.to_vec();
+    true
+}
+
+fn stream_filters(stream: &Stream) -> Option<Vec<Vec<u8>>> {
+    match stream.dict.get(b"Filter").ok()? {
+        Object::Name(name) => Some(vec![canonical_filter_name(name).to_vec()]),
+        Object::Array(filters) => {
+            let mut names = Vec::with_capacity(filters.len());
+            for filter in filters {
+                let Object::Name(name) = filter else {
+                    return None;
+                };
+                names.push(canonical_filter_name(name).to_vec());
+            }
+            Some(names)
+        }
+        _ => None,
+    }
+}
+
+fn decode_params_at(params: Option<&Object>, index: usize) -> Option<&Dictionary> {
+    match params? {
+        Object::Dictionary(params) => Some(params),
+        Object::Array(params) => params.get(index).and_then(|params| match params {
+            Object::Dictionary(params) => Some(params),
+            _ => None,
+        }),
+        _ => None,
+    }
+}
+
+fn decode_filter(
+    filter: &[u8],
+    input: &[u8],
+    params: Option<&Dictionary>,
+) -> lopdf::Result<Vec<u8>> {
+    match filter {
+        b"ASCIIHexDecode" => decode_ascii_hex(input),
+        b"RunLengthDecode" => decode_run_length(input),
+        b"FlateDecode" | b"LZWDecode" | b"ASCII85Decode" => {
+            decode_with_lopdf(filter, input, params)
+        }
+        _ => Err(lopdf::Error::Unimplemented("decompression algorithms")),
+    }
+}
+
+fn decode_with_lopdf(
+    filter: &[u8],
+    input: &[u8],
+    params: Option<&Dictionary>,
+) -> lopdf::Result<Vec<u8>> {
+    let mut dict = Dictionary::new();
+    dict.set("Filter", Object::Name(filter.to_vec()));
+    if let Some(params) = params {
+        dict.set("DecodeParms", Object::Dictionary(params.clone()));
+    }
+    Stream::new(dict, input.to_vec()).decompressed_content()
+}
+
+fn decode_ascii_hex(input: &[u8]) -> lopdf::Result<Vec<u8>> {
+    let mut output = Vec::with_capacity(input.len() / 2);
+    let mut high = None;
+    for &byte in input {
+        if byte == b'>' {
+            break;
+        }
+        if byte.is_ascii_whitespace() {
+            continue;
+        }
+        let Some(nibble) = hex_nibble(byte) else {
+            return Err(lopdf::Error::InvalidStream(format!(
+                "invalid ASCIIHexDecode byte 0x{byte:02x}"
+            )));
+        };
+        match high.take() {
+            Some(high) => output.push((high << 4) | nibble),
+            None => high = Some(nibble),
+        }
+    }
+    if let Some(high) = high {
+        output.push(high << 4);
+    }
+    Ok(output)
+}
+
+fn hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn decode_run_length(input: &[u8]) -> lopdf::Result<Vec<u8>> {
+    let mut output = Vec::with_capacity(input.len());
+    let mut index = 0usize;
+    while index < input.len() {
+        let length = input[index];
+        index += 1;
+        match length {
+            0..=127 => {
+                let count = length as usize + 1;
+                let end = index.checked_add(count).ok_or_else(|| {
+                    lopdf::Error::InvalidStream("RunLengthDecode literal length overflow".into())
+                })?;
+                let literal = input.get(index..end).ok_or_else(|| {
+                    lopdf::Error::InvalidStream("truncated RunLengthDecode literal run".into())
+                })?;
+                output.extend_from_slice(literal);
+                index = end;
+            }
+            128 => break,
+            129..=255 => {
+                let byte = *input.get(index).ok_or_else(|| {
+                    lopdf::Error::InvalidStream("truncated RunLengthDecode repeat run".into())
+                })?;
+                index += 1;
+                output.extend(std::iter::repeat_n(byte, 257usize - length as usize));
+            }
+        }
+    }
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use lopdf::{dictionary, Object, Stream};
+
+    use super::{decode_stream_content, normalize_stream_filter_names, FILTER_ABBREVIATIONS};
+
+    #[test]
+    fn normalizes_all_pdf_filter_name_abbreviations() {
+        for (abbreviation, canonical) in FILTER_ABBREVIATIONS {
+            let mut stream = Stream::new(
+                dictionary! {
+                    "Filter" => Object::Name(abbreviation.to_vec()),
+                },
+                Vec::new(),
+            );
+            assert!(normalize_stream_filter_names(&mut stream));
+            assert_eq!(
+                stream.dict.get(b"Filter").unwrap().as_name().unwrap(),
+                canonical
+            );
+        }
+    }
+
+    #[test]
+    fn normalizes_abbreviated_filter_arrays() {
+        let mut stream = Stream::new(
+            dictionary! {
+                "Filter" => Object::Array(vec![
+                    Object::Name(b"AHx".to_vec()),
+                    Object::Name(b"Fl".to_vec()),
+                    Object::Name(b"DCT".to_vec()),
+                ]),
+            },
+            Vec::new(),
+        );
+        assert!(normalize_stream_filter_names(&mut stream));
+        let filters = stream.dict.get(b"Filter").unwrap().as_array().unwrap();
+        let names = filters
+            .iter()
+            .map(|filter| filter.as_name().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            vec![
+                b"ASCIIHexDecode".as_slice(),
+                b"FlateDecode".as_slice(),
+                b"DCTDecode".as_slice()
+            ]
+        );
+    }
+
+    #[test]
+    fn decodes_abbreviated_ascii_hex_and_run_length_streams() {
+        let ascii_hex = Stream::new(
+            dictionary! {
+                "Filter" => "AHx",
+            },
+            b"48 65 6c 6c 6f>".to_vec(),
+        );
+        assert_eq!(decode_stream_content(&ascii_hex).unwrap(), b"Hello");
+
+        let run_length = Stream::new(
+            dictionary! {
+                "Filter" => "RL",
+            },
+            vec![4, b'H', b'e', b'l', b'l', b'o', 128],
+        );
+        assert_eq!(decode_stream_content(&run_length).unwrap(), b"Hello");
+    }
+}

--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -9,6 +9,7 @@ use lopdf::{xref::XrefEntry, Document, Object, ObjectId, ObjectStream, Reader};
 
 use crate::{
     copy::ObjectSource,
+    filter::normalize_stream_filter_names,
     load::{decorate_load_error, ensure_decrypted, load_options, upgrade_damaged_xref_error},
     PdfOpsError, Result,
 };
@@ -415,6 +416,7 @@ impl<'a> LazyPdf<'a> {
         let mut already_seen = HashSet::new();
         let container_object = self.reader.get_object(container_id, &mut already_seen)?;
         let mut container_stream = container_object.as_stream()?.clone();
+        normalize_stream_filter_names(&mut container_stream);
         let object_stream = Arc::new(ObjectStream::new(&mut container_stream)?.objects);
         self.object_streams
             .lock()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod copy;
 pub mod count;
+mod filter;
 pub mod lazy;
 pub mod load;
 pub mod merge;

--- a/src/load.rs
+++ b/src/load.rs
@@ -3,7 +3,9 @@ use std::{fs::File, path::Path};
 use lopdf::{Document, FilterFunc, LoadOptions};
 use memmap2::{Mmap, MmapOptions};
 
-use crate::{range::PageRangeError, PdfOpsError, Result};
+use crate::{
+    filter::normalize_filter_names_for_lopdf_load, range::PageRangeError, PdfOpsError, Result,
+};
 
 /// Load a whole document eagerly, transparently decrypting encrypted inputs.
 ///
@@ -18,8 +20,11 @@ use crate::{range::PageRangeError, PdfOpsError, Result};
 /// unencrypted.
 pub(crate) fn load_document(path: &Path, password: Option<&str>) -> Result<Document> {
     let mmap = map_file(path)?;
-    let document = Document::load_mem_with_options(&mmap, load_options(password, None))
-        .map_err(|err| decorate_load_error(err, path))?;
+    let document = Document::load_mem_with_options(
+        &mmap,
+        load_options(password, Some(normalize_filter_names_for_lopdf_load)),
+    )
+    .map_err(|err| decorate_load_error(err, path))?;
     ensure_decrypted(&document, path)?;
     if document.page_iter().next().is_none() {
         return Err(PdfOpsError::Range(PageRangeError::NoPages));

--- a/src/repair.rs
+++ b/src/repair.rs
@@ -33,6 +33,7 @@ use lopdf::{
 use memchr::memmem;
 
 use crate::{
+    filter::decode_stream_content,
     lazy::PdfSource,
     xrefboot::{is_delimiter, is_whitespace, parse_version, Lexer},
     PdfOpsError, Result,
@@ -448,9 +449,7 @@ fn expand_object_stream(
     let stream = lopdf::Stream::new(candidate.dict.clone(), content.to_vec());
     // An undecodable stream contributes nothing; an unfiltered one is its own
     // decoded content.
-    let decoded = stream
-        .decompressed_content()
-        .unwrap_or_else(|_| content.to_vec());
+    let decoded = decode_stream_content(&stream).unwrap_or_else(|_| content.to_vec());
     let first = candidate
         .dict
         .get(b"First")

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -6,7 +6,7 @@ use std::{
 
 use lopdf::{content::Content, Dictionary, Object, ObjectId};
 
-use crate::{copy::ObjectSource, Result};
+use crate::{copy::ObjectSource, filter::decode_stream_content, Result};
 
 const MAX_FORM_RESOURCE_DEPTH: usize = 32;
 
@@ -167,7 +167,7 @@ fn collect_form_names(
         }
 
         let Some(form_used) = scan_names_cached(id, state.used_names_cache, || {
-            stream.decompressed_content().ok()
+            decode_stream_content(&stream).ok()
         }) else {
             if strict_own_form_failures {
                 return Ok(false);
@@ -309,7 +309,7 @@ fn content_bytes(source: &impl ObjectSource, page: &Dictionary) -> Result<Option
             }))
         }
         Object::Stream(stream) => {
-            let Ok(decoded) = stream.decompressed_content() else {
+            let Ok(decoded) = decode_stream_content(stream) else {
                 return Ok(None);
             };
             Ok(Some(ContentBytes {
@@ -342,7 +342,7 @@ fn content_stream_bytes(source: &impl ObjectSource, id: ObjectId) -> Result<Opti
     let Ok(stream) = object.as_stream() else {
         return Ok(None);
     };
-    let Ok(decoded) = stream.decompressed_content() else {
+    let Ok(decoded) = decode_stream_content(stream) else {
         return Ok(None);
     };
     Ok(Some(decoded))

--- a/src/xrefboot.rs
+++ b/src/xrefboot.rs
@@ -24,6 +24,8 @@ use lopdf::{
     Dictionary, Document, Object, Stream, StringFormat,
 };
 
+use crate::filter::decode_stream_content;
+
 /// Upper bound on incremental-update sections we are willing to follow.
 const MAX_CHAIN_SECTIONS: usize = 1024;
 /// Maximum nesting depth for trailer-dictionary values.
@@ -312,7 +314,7 @@ fn parse_stream_section(mut lexer: Lexer) -> Option<Section> {
     }
 
     let stream = Stream::new(dict, raw_content.to_vec());
-    let content = stream.decompressed_content().ok()?;
+    let content = decode_stream_content(&stream).ok()?;
     let mut trailer = stream.dict;
 
     let sink = decode_stream_entries(&content, &trailer)?;

--- a/tests/split_merge.rs
+++ b/tests/split_merge.rs
@@ -1,5 +1,6 @@
 use std::{
     fs,
+    io::Write,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -243,6 +244,44 @@ fn page_count_library_matches_object_stream_input() {
     // Object-stream (compressed xref) input exercises the lazy reader's
     // compressed-object path, mirroring the split-pages fixtures.
     assert_eq!(page_count(&fixture("11-pages-objstm.pdf")).unwrap(), 11);
+}
+
+#[test]
+fn operations_handle_filter_abbreviations_in_xref_object_and_content_streams() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("filter-abbreviation.pdf");
+    let split_output = temp.path().join("split.pdf");
+    let merged = temp.path().join("merged.pdf");
+
+    write_filter_abbreviation_pdf(&input);
+
+    assert_eq!(page_count(&input).unwrap(), 1);
+    assert_eq!(page_count_fast(&input).unwrap(), 1);
+
+    split(
+        &input,
+        &[SplitOutput {
+            range: PageRangeGroup::parse("1").unwrap(),
+            path: split_output.clone(),
+        }],
+    )
+    .unwrap();
+    assert_written(&split_output);
+
+    merge(
+        &[MergeInput {
+            path: input,
+            ranges: vec![PageRangeGroup::parse("1").unwrap()],
+        }],
+        &merged,
+    )
+    .unwrap();
+    assert_written(&merged);
+
+    let qpdf = QpdfValidator::detect();
+    qpdf.validate(&split_output, 1);
+    qpdf.validate(&merged, 1);
+    assert_page_resources(&split_output, &qpdf, &["X0"], &[]);
 }
 
 #[test]
@@ -1099,6 +1138,120 @@ fn split_rejects_duplicate_output_paths_before_writing() {
 
 /// Three real leaf pages; the root /Pages carries `count` verbatim as /Count
 /// (or omits the key entirely) so tests can probe the trusted-count fast path.
+fn write_filter_abbreviation_pdf(path: &Path) {
+    let mut pdf = Vec::new();
+    let mut offsets = [0usize; 11];
+
+    pdf.extend_from_slice(b"%PDF-1.5\n%\xff\xff\xff\xff\n");
+
+    let (object_stream, first) = object_stream_content(&[
+        (2, b"<< /Type /Catalog /Pages 3 0 R >>".as_slice()),
+        (3, b"<< /Type /Pages /Kids [4 0 R] /Count 1 >>".as_slice()),
+        (
+            4,
+            b"<< /Type /Page /Parent 3 0 R /MediaBox [0 0 100 100] \
+              /Resources 5 0 R /Contents 7 0 R >>"
+                .as_slice(),
+        ),
+        (
+            5,
+            b"<< /XObject << /X0 8 0 R /X1 9 0 R /X2 9 0 R /X3 9 0 R \
+              /X4 9 0 R /X5 9 0 R /X6 9 0 R >> >>"
+                .as_slice(),
+        ),
+    ]);
+    let compressed_object_stream = zlib_compress(&object_stream);
+    offsets[1] = push_stream_object(
+        &mut pdf,
+        1,
+        &format!("/Type /ObjStm /Filter /Fl /N 4 /First {first}"),
+        &compressed_object_stream,
+    );
+
+    let compressed_content = zlib_compress(b"q /X0 Do Q");
+    offsets[7] = push_stream_object(&mut pdf, 7, "/Filter /Fl", &compressed_content);
+    offsets[8] = push_stream_object(
+        &mut pdf,
+        8,
+        "/Type /XObject /Subtype /Form /BBox [0 0 10 10] /Resources << >>",
+        b"q Q",
+    );
+    offsets[9] = push_stream_object(
+        &mut pdf,
+        9,
+        "/Type /XObject /Subtype /Form /BBox [0 0 10 10] /Resources << >>",
+        b"q Q",
+    );
+
+    offsets[10] = pdf.len();
+    let mut xref_rows = Vec::new();
+    push_xref_row(&mut xref_rows, 0, 0, u16::MAX);
+    push_xref_row(&mut xref_rows, 1, offsets[1] as u32, 0);
+    for (index, object_number) in (2u16..=5).enumerate() {
+        assert_eq!(object_number as usize, index + 2);
+        push_xref_row(&mut xref_rows, 2, 1, index as u16);
+    }
+    push_xref_row(&mut xref_rows, 0, 0, u16::MAX);
+    push_xref_row(&mut xref_rows, 1, offsets[7] as u32, 0);
+    push_xref_row(&mut xref_rows, 1, offsets[8] as u32, 0);
+    push_xref_row(&mut xref_rows, 1, offsets[9] as u32, 0);
+    push_xref_row(&mut xref_rows, 1, offsets[10] as u32, 0);
+
+    let compressed_xref = zlib_compress(&xref_rows);
+    push_stream_object(
+        &mut pdf,
+        10,
+        "/Type /XRef /Filter /Fl /Size 11 /Index [0 11] /W [1 4 2] /Root 2 0 R",
+        &compressed_xref,
+    );
+    write!(pdf, "startxref\n{}\n%%EOF\n", offsets[10]).unwrap();
+
+    fs::write(path, pdf).unwrap_or_else(|err| {
+        panic!(
+            "failed to write filter abbreviation fixture {}: {err}",
+            path.display()
+        )
+    });
+}
+
+fn object_stream_content(objects: &[(u32, &[u8])]) -> (Vec<u8>, usize) {
+    let mut header = Vec::new();
+    let mut body = Vec::new();
+    for (object_number, object) in objects {
+        write!(header, "{object_number} {} ", body.len()).unwrap();
+        body.extend_from_slice(object);
+        body.push(b'\n');
+    }
+    let first = header.len();
+    header.extend_from_slice(&body);
+    (header, first)
+}
+
+fn push_stream_object(pdf: &mut Vec<u8>, id: u32, dict_entries: &str, content: &[u8]) -> usize {
+    let offset = pdf.len();
+    write!(
+        pdf,
+        "{id} 0 obj\n<< {dict_entries} /Length {} >>\nstream\n",
+        content.len()
+    )
+    .unwrap();
+    pdf.extend_from_slice(content);
+    pdf.extend_from_slice(b"\nendstream\nendobj\n");
+    offset
+}
+
+fn push_xref_row(rows: &mut Vec<u8>, entry_type: u8, second: u32, third: u16) {
+    rows.push(entry_type);
+    rows.extend_from_slice(&second.to_be_bytes());
+    rows.extend_from_slice(&third.to_be_bytes());
+}
+
+fn zlib_compress(data: &[u8]) -> Vec<u8> {
+    let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(data).unwrap();
+    encoder.finish().unwrap()
+}
+
 fn write_three_page_pdf_with_count(path: &Path, count: Option<Object>) {
     let mut document = Document::with_version("1.7");
     let catalog_id = document.new_object_id();


### PR DESCRIPTION
## Summary
- Normalize PDF filter abbreviations such as `/Fl`, `/AHx`, `/RL`, and `/DCT` before decoding.
- Use the decoder in xref stream bootstrap, eager load, lazy object streams, repair, page content scanning, and Form XObject pruning.
- Add a regression PDF covering abbreviated filters in xref streams, ObjStm streams, content streams, and pruning.

Fixes #12.

## Validation
- `cargo test filter:: --lib`
- `cargo test --test split_merge operations_handle_filter_abbreviations_in_xref_object_and_content_streams -- --nocapture`
- `cargo check --all-targets`
- `git diff --check`
