### PR TITLE
fix(pages): infer missing page tree types

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -8,7 +8,10 @@ use std::{
 
 use lopdf::{Dictionary, Document, Object, ObjectId};
 
-use crate::{filter::decode_stream_content, scan, scan::UsedNames, PdfOpsError, Result};
+use crate::{
+    filter::decode_stream_content, lazy::inferred_page_leaf, scan, scan::UsedNames, PdfOpsError,
+    Result,
+};
 
 const INHERITABLE_PAGE_ATTRS: [&[u8]; 4] = [b"Resources", b"MediaBox", b"CropBox", b"Rotate"];
 const MAX_COPY_DEPTH: usize = 256;
@@ -107,20 +110,43 @@ impl CopyContext {
         let new_id = if self.selected_pages.contains(&page_id) {
             self.copy_page_instance(source, target, page_id)?
         } else {
-            let new_id = self.copy_object(source, target, page_id)?;
+            let new_id = self.copy_first_page_instance(source, target, page_id)?;
             self.selected_pages.insert(page_id);
             new_id
         };
-        let page = target
-            .get_object(new_id)
-            .map_err(PdfOpsError::Pdf)?
+        Ok(new_id)
+    }
+
+    fn copy_first_page_instance(
+        &mut self,
+        source: &impl ObjectSource,
+        target: &mut Document,
+        old_page_id: ObjectId,
+    ) -> Result<ObjectId> {
+        let object = source
+            .get_object_value(old_page_id)
+            .map_err(PdfOpsError::Pdf)?;
+        let page = object
             .as_dict()
-            .map_err(|_| PdfOpsError::InvalidStructure("copied page is not a dictionary".into()))?;
-        if !page.has_type(b"Page") {
+            .map_err(|_| PdfOpsError::InvalidStructure("page is not a dictionary".into()))?;
+        if !inferred_page_leaf(page) {
             return Err(PdfOpsError::InvalidStructure(
                 "copied page does not have /Type /Page".into(),
             ));
         }
+
+        let new_id = target.new_object_id();
+        let previous = self.object_map.insert(old_page_id, new_id);
+        target.objects.insert(new_id, Object::Null);
+
+        let copied = match self.copy_page_dictionary(source, target, old_page_id, page, 0) {
+            Ok(copied) => copied,
+            Err(err) => {
+                restore_object_mapping(&mut self.object_map, old_page_id, previous);
+                return Err(err);
+            }
+        };
+        target.objects.insert(new_id, Object::Dictionary(copied));
         Ok(new_id)
     }
 
@@ -136,7 +162,7 @@ impl CopyContext {
         let page = object
             .as_dict()
             .map_err(|_| PdfOpsError::InvalidStructure("page is not a dictionary".into()))?;
-        if !page.has_type(b"Page") {
+        if !inferred_page_leaf(page) {
             return Err(PdfOpsError::InvalidStructure(
                 "copied page does not have /Type /Page".into(),
             ));
@@ -158,6 +184,7 @@ impl CopyContext {
         Ok(new_id)
     }
 
+    #[cfg(test)]
     pub(crate) fn copy_object(
         &mut self,
         source: &impl ObjectSource,
@@ -279,6 +306,7 @@ impl CopyContext {
             }
         }
 
+        copied.set("Type", "Page");
         Ok(copied)
     }
 

--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -351,7 +351,6 @@ impl<'a> LazyPdf<'a> {
                         stack.push((kid_id, depth + 1));
                     }
                 }
-                PageNode::Other => {}
             }
         }
 
@@ -383,7 +382,7 @@ impl<'a> LazyPdf<'a> {
             let object = objects
                 .get(&(id.0, 0))
                 .ok_or(PdfOpsError::Pdf(lopdf::Error::ObjectNotFound(id)))?;
-            return classify_page_dict(object);
+            return classify_page_dict(id, object);
         }
 
         let mut already_seen = HashSet::new();
@@ -391,7 +390,7 @@ impl<'a> LazyPdf<'a> {
             .reader
             .get_object(id, &mut already_seen)
             .map_err(|err| PdfOpsError::Pdf(normalize_missing_xref(err, id)))?;
-        classify_page_dict(&object)
+        classify_page_dict(id, &object)
     }
 
     fn get_owned(&self, id: ObjectId) -> Result<Object> {
@@ -472,42 +471,75 @@ impl ObjectSource for LazyPdf<'_> {
 enum PageNode {
     Leaf,
     Interior(Vec<ObjectId>),
-    Other,
 }
 
-fn classify_page_dict(object: &Object) -> Result<PageNode> {
-    let dict = object
-        .as_dict()
-        .map_err(|_| PdfOpsError::InvalidStructure("page tree node is not a dictionary".into()))?;
-    match dict.get_type().map_err(PdfOpsError::Pdf)? {
-        b"Page" => Ok(PageNode::Leaf),
-        b"Pages" => {
-            let kids = dict
-                .get(b"Kids")
-                .and_then(Object::as_array)
-                .map_err(PdfOpsError::Pdf)?;
-            let mut kid_ids = Vec::with_capacity(kids.len());
-            for kid in kids {
-                match kid {
-                    Object::Reference(kid_id) => kid_ids.push(*kid_id),
-                    // A direct page dict has no object id, so split could
-                    // never copy it; refuse loudly instead of silently
-                    // under-counting (qpdf-qtest 0213).
-                    Object::Dictionary(_) => {
-                        return Err(PdfOpsError::InvalidStructure(
-                            "page tree kid is a direct object; pages must be \
-                             indirect references"
-                                .into(),
-                        ));
-                    }
-                    // tolerate nulls and other junk in Kids arrays
-                    _ => {}
-                }
-            }
-            Ok(PageNode::Interior(kid_ids))
-        }
-        _ => Ok(PageNode::Other),
+enum PageNodeKind {
+    Leaf,
+    Interior,
+}
+
+fn classify_page_dict(id: ObjectId, object: &Object) -> Result<PageNode> {
+    let dict = object.as_dict().map_err(|_| {
+        PdfOpsError::InvalidStructure(format!(
+            "page tree node {} {} R is not a dictionary",
+            id.0, id.1
+        ))
+    })?;
+
+    match page_node_kind(dict) {
+        PageNodeKind::Leaf => Ok(PageNode::Leaf),
+        PageNodeKind::Interior => classify_page_tree_interior(id, dict),
     }
+}
+
+fn page_node_kind(dict: &Dictionary) -> PageNodeKind {
+    match dict.get(b"Type") {
+        Ok(Object::Name(name)) if name == b"Page" => PageNodeKind::Leaf,
+        Ok(Object::Name(name)) if name == b"Pages" => PageNodeKind::Interior,
+        _ if dict.has(b"Kids") => PageNodeKind::Interior,
+        _ => PageNodeKind::Leaf,
+    }
+}
+
+pub(crate) fn inferred_page_leaf(dict: &Dictionary) -> bool {
+    matches!(page_node_kind(dict), PageNodeKind::Leaf)
+}
+
+fn classify_page_tree_interior(id: ObjectId, dict: &Dictionary) -> Result<PageNode> {
+    let kids = match dict.get(b"Kids") {
+        Ok(Object::Array(kids)) => kids,
+        Ok(other) => {
+            return Err(PdfOpsError::InvalidStructure(format!(
+                "page tree node {} {} R has /Kids as {}, expected array",
+                id.0,
+                id.1,
+                other.enum_variant()
+            )));
+        }
+        Err(_) => {
+            return Err(PdfOpsError::InvalidStructure(format!(
+                "page tree node {} {} R is an interior page-tree node but is missing /Kids",
+                id.0, id.1
+            )));
+        }
+    };
+
+    let mut kid_ids = Vec::with_capacity(kids.len());
+    for (index, kid) in kids.iter().enumerate() {
+        match kid {
+            Object::Reference(kid_id) => kid_ids.push(*kid_id),
+            other => {
+                return Err(PdfOpsError::InvalidStructure(format!(
+                    "page tree node {} {} R has direct/non-reference /Kids[{index}] as {}; \
+                     page tree kids must be indirect references",
+                    id.0,
+                    id.1,
+                    other.enum_variant()
+                )));
+            }
+        }
+    }
+    Ok(PageNode::Interior(kid_ids))
 }
 
 fn drop_object(_: ObjectId, _: &mut Object) -> Option<(ObjectId, Object)> {

--- a/src/split.rs
+++ b/src/split.rs
@@ -8,6 +8,7 @@ use rayon::prelude::*;
 
 use crate::{
     copy::{copy_pages_with_options, resolve_page_ids, CopyOptions, ObjectSource},
+    lazy::inferred_page_leaf,
     load::{load_document, map_file},
     merge::merge_whole_inputs_streaming,
     range::{PageRangeError, PageRangeGroup},
@@ -389,11 +390,12 @@ pub(crate) fn finish_pages(target: &mut Document, pages: &[lopdf::ObjectId]) -> 
             .get_object_mut(*page_id)?
             .as_dict_mut()
             .map_err(|_| PdfOpsError::InvalidStructure("page is not a dictionary".into()))?;
-        if !page.has_type(b"Page") {
+        if !inferred_page_leaf(page) {
             return Err(PdfOpsError::InvalidStructure(
                 "pages tree kid does not have /Type /Page".into(),
             ));
         }
+        page.set("Type", "Page");
         page.set("Parent", pages_id);
     }
     target.objects.insert(

--- a/src/write.rs
+++ b/src/write.rs
@@ -11,6 +11,7 @@ use lopdf::{dictionary, Dictionary, Object, ObjectId, StringFormat};
 
 use crate::{
     copy::{CopyOptions, ObjectSource},
+    lazy::inferred_page_leaf,
     PdfOpsError, Result,
 };
 
@@ -146,10 +147,41 @@ impl<'a> StreamingCopyContext<'a> {
         let new_id = if self.selected_pages.contains(&page_id) {
             self.copy_page_instance(source, page_id)?
         } else {
-            let new_id = self.copy_object_at_depth(source, page_id, 0)?;
+            let new_id = self.copy_first_page_instance(source, page_id)?;
             self.selected_pages.insert(page_id);
             new_id
         };
+        Ok(new_id)
+    }
+
+    fn copy_first_page_instance(
+        &mut self,
+        source: &impl ObjectSource,
+        old_page_id: ObjectId,
+    ) -> Result<ObjectId> {
+        let object = source
+            .get_object_value(old_page_id)
+            .map_err(PdfOpsError::Pdf)?;
+        let page = object
+            .as_dict()
+            .map_err(|_| PdfOpsError::InvalidStructure("page is not a dictionary".into()))?;
+        if !inferred_page_leaf(page) {
+            return Err(PdfOpsError::InvalidStructure(
+                "copied page does not have /Type /Page".into(),
+            ));
+        }
+
+        let new_id = self.writer.new_object_id();
+        let previous = self.object_map.insert(old_page_id, new_id);
+        let copied = match self.copy_page_dictionary(source, old_page_id, page, 0) {
+            Ok(copied) => copied,
+            Err(err) => {
+                restore_object_mapping(&mut self.object_map, old_page_id, previous);
+                return Err(err);
+            }
+        };
+        self.writer
+            .write_object(new_id, &Object::Dictionary(copied))?;
         Ok(new_id)
     }
 
@@ -164,7 +196,7 @@ impl<'a> StreamingCopyContext<'a> {
         let page = object
             .as_dict()
             .map_err(|_| PdfOpsError::InvalidStructure("page is not a dictionary".into()))?;
-        if !page.has_type(b"Page") {
+        if !inferred_page_leaf(page) {
             return Err(PdfOpsError::InvalidStructure(
                 "copied page does not have /Type /Page".into(),
             ));
@@ -260,6 +292,7 @@ impl<'a> StreamingCopyContext<'a> {
             }
         }
         copied.set("Parent", self.writer.pages_id());
+        copied.set("Type", "Page");
 
         Ok(copied)
     }

--- a/tests/split_merge.rs
+++ b/tests/split_merge.rs
@@ -337,6 +337,129 @@ fn page_count_fast_trusts_plausible_count_by_design() {
 }
 
 #[test]
+fn page_count_infers_missing_or_bogus_page_tree_types() {
+    let temp = tempdir().unwrap();
+    let cases = [
+        ("missing-interior", None, Some(b"Page".as_ref())),
+        (
+            "bogus-interior",
+            Some(b"Pagez".as_ref()),
+            Some(b"Page".as_ref()),
+        ),
+        ("missing-leaf", Some(b"Pages".as_ref()), None),
+        (
+            "bogus-leaf",
+            Some(b"Pages".as_ref()),
+            Some(b"Pagez".as_ref()),
+        ),
+        ("missing-both", None, None),
+        (
+            "bogus-both",
+            Some(b"Pagez".as_ref()),
+            Some(b"Pagez".as_ref()),
+        ),
+    ];
+
+    for (label, pages_type, page_type) in cases {
+        let input = temp.path().join(format!("{label}.pdf"));
+        write_page_tree_type_inference_pdf(&input, pages_type, page_type);
+        assert_eq!(
+            page_count(&input).unwrap(),
+            1,
+            "strict walk should infer page-tree node kind for {label}"
+        );
+    }
+}
+
+#[test]
+fn split_normalizes_inferred_page_tree_leaf_types() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("missing-leaf-type.pdf");
+    let split_output = temp.path().join("split.pdf");
+    let split_pages_pattern = temp.path().join("page-%d.pdf");
+
+    write_page_tree_type_inference_pdf(&input, Some(b"Pages"), None);
+
+    split(
+        &input,
+        &[SplitOutput {
+            range: PageRangeGroup::parse("1").unwrap(),
+            path: split_output.clone(),
+        }],
+    )
+    .unwrap();
+    split_pages(&input, split_pages_pattern.to_str().unwrap()).unwrap();
+
+    let split_page_output = temp.path().join("page-1.pdf");
+    assert_written(&split_output);
+    assert_written(&split_page_output);
+
+    let qpdf = QpdfValidator::detect();
+    qpdf.validate(&split_output, 1);
+    qpdf.validate(&split_page_output, 1);
+
+    for output in [&split_output, &split_page_output] {
+        let document = Document::load(output)
+            .unwrap_or_else(|err| panic!("failed to load {}: {err}", output.display()));
+        let page_id = document.get_pages()[&1];
+        let page = document
+            .get_object(page_id)
+            .unwrap()
+            .as_dict()
+            .unwrap_or_else(|_| {
+                panic!("page object should be a dictionary in {}", output.display())
+            });
+        assert!(
+            page.has_type(b"Page"),
+            "{} should write /Type /Page",
+            output.display()
+        );
+    }
+}
+
+#[test]
+#[ignore = "external qpdf fixture is not checked into the repository"]
+fn page_count_reads_no_pages_types_fixture_when_available() {
+    let input = fixture("no-pages-types.pdf");
+    if !input.exists() {
+        eprintln!("no-pages-types.pdf fixture unavailable; skipping qpdf fixture regression");
+        return;
+    }
+
+    assert_eq!(page_count(&input).unwrap(), 1);
+}
+
+#[test]
+fn page_count_reports_clear_error_for_unwalkable_inferred_interior() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("bad-kids-type.pdf");
+    write_page_tree_with_bad_kids(&input, Object::Name(b"not-an-array".to_vec()));
+
+    let err = page_count(&input).unwrap_err().to_string();
+    assert!(
+        err.contains("2 0 R") && err.contains("/Kids") && err.contains("expected array"),
+        "expected a contextual /Kids error, got: {err}"
+    );
+    assert!(
+        !err.contains("Linearized"),
+        "page tree errors should not leak lopdf's get_type fallback: {err}"
+    );
+}
+
+#[test]
+fn page_count_rejects_non_reference_page_tree_kids() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("null-page-tree-kid.pdf");
+    write_page_tree_with_bad_kids(&input, Object::Array(vec![Object::Null]));
+
+    let err = page_count(&input).unwrap_err().to_string();
+    assert!(
+        err.contains("2 0 R") && err.contains("/Kids[0]") && err.contains("indirect references"),
+        "expected a contextual non-reference kid error, got: {err}"
+    );
+}
+
+#[test]
 fn page_count_encrypted_inputs_behave_the_same_in_both_modes() {
     // A real user password is required: without it both modes fail with the
     // password error, never a wrong count.
@@ -1290,6 +1413,78 @@ fn write_three_page_pdf_with_count(path: &Path, count: Option<Object>) {
     document
         .save(path)
         .unwrap_or_else(|err| panic!("failed to save page-count fixture: {err}"));
+}
+
+fn write_page_tree_type_inference_pdf(
+    path: &Path,
+    pages_type: Option<&[u8]>,
+    page_type: Option<&[u8]>,
+) {
+    let mut document = Document::with_version("1.7");
+    let catalog_id = document.new_object_id();
+    let pages_id = document.new_object_id();
+    let page_id = document.new_object_id();
+
+    document.objects.insert(
+        catalog_id,
+        dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        }
+        .into(),
+    );
+
+    let mut pages = Dictionary::new();
+    set_optional_type(&mut pages, pages_type);
+    pages.set("Kids", Object::Array(vec![Object::Reference(page_id)]));
+    pages.set("Count", 1);
+    document.objects.insert(pages_id, Object::Dictionary(pages));
+
+    let mut page = Dictionary::new();
+    set_optional_type(&mut page, page_type);
+    page.set("Parent", pages_id);
+    page.set(
+        "MediaBox",
+        Object::Array(vec![0.into(), 0.into(), 100.into(), 100.into()]),
+    );
+    page.set("Resources", Dictionary::new());
+    document.objects.insert(page_id, Object::Dictionary(page));
+
+    document.trailer.set("Root", catalog_id);
+    document
+        .save(path)
+        .unwrap_or_else(|err| panic!("failed to save page-tree type fixture: {err}"));
+}
+
+fn set_optional_type(dict: &mut Dictionary, type_name: Option<&[u8]>) {
+    if let Some(type_name) = type_name {
+        dict.set("Type", Object::Name(type_name.to_vec()));
+    }
+}
+
+fn write_page_tree_with_bad_kids(path: &Path, kids: Object) {
+    let mut document = Document::with_version("1.7");
+    let catalog_id = document.new_object_id();
+    let pages_id = document.new_object_id();
+
+    document.objects.insert(
+        catalog_id,
+        dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        }
+        .into(),
+    );
+
+    let mut pages = Dictionary::new();
+    pages.set("Kids", kids);
+    pages.set("Count", 1);
+    document.objects.insert(pages_id, Object::Dictionary(pages));
+
+    document.trailer.set("Root", catalog_id);
+    document
+        .save(path)
+        .unwrap_or_else(|err| panic!("failed to save bad page-tree fixture: {err}"));
 }
 
 fn write_simple_pdf(path: &Path, page_count: usize) {


### PR DESCRIPTION
## Summary
- Infer page-tree node kind structurally when `/Type` is missing or bogus.
- Treat nodes with `/Kids` as `/Pages`; otherwise treat them as `/Page`.
- Normalize copied page outputs back to `/Type /Page` so `page-count` and `split` agree.
- Report contextual errors for malformed `/Kids` instead of leaking unrelated lopdf errors.

Fixes #8.

## Stack
Base branch: `hcunha/xref-tiff-predictor` (#9).

## Validation
- `cargo test --test split_merge page_count_infers_missing_or_bogus_page_tree_types -- --nocapture`
- `cargo test --test split_merge split_normalizes_inferred_page_tree_leaf_types -- --nocapture`
- `cargo test --test split_merge page_count_reports_clear_error_for_unwalkable_inferred_interior -- --nocapture`
- `cargo test --test split_merge page_count_rejects_non_reference_page_tree_kids -- --nocapture`
- `cargo check --all-targets`
- `git diff --check`
