### PR TITLE
fix(pruning): tolerate content stream comments

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -16,7 +16,6 @@ use crate::{
 const INHERITABLE_PAGE_ATTRS: [&[u8]; 4] = [b"Resources", b"MediaBox", b"CropBox", b"Rotate"];
 const MAX_COPY_DEPTH: usize = 256;
 const RESOURCE_PRUNE_MIN_NAMES: usize = 6;
-
 pub(crate) trait ObjectSource {
     fn get_object_value(&self, id: ObjectId) -> std::result::Result<Cow<'_, Object>, lopdf::Error>;
 }
@@ -338,11 +337,15 @@ impl CopyContext {
             &mut self.used_names_cache,
         )?
         else {
+            record_resource_prune_fallback();
             return self.copy_value(source, target, value, depth + 1);
         };
         match self.copy_pruned_resources(source, target, &resources, &used, depth + 1)? {
             Some(pruned) => Ok(pruned),
-            None => self.copy_value(source, target, value, depth + 1),
+            None => {
+                record_resource_prune_fallback();
+                self.copy_value(source, target, value, depth + 1)
+            }
         }
     }
 
@@ -678,6 +681,10 @@ impl CopyContext {
         self.inherited_attrs_cache.insert(id, Arc::clone(&attrs));
         Ok(Some(attrs))
     }
+}
+
+fn record_resource_prune_fallback() {
+    crate::split::record_resource_prune_fallback();
 }
 
 enum ResolvedDictionary<'a> {

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     collections::{BTreeMap, BTreeSet, VecDeque},
     ops::Deref,
     rc::Rc,
@@ -223,7 +224,8 @@ fn collect_form_names(
 }
 
 fn scan_names(data: &[u8]) -> Option<UsedNames> {
-    let content = Content::decode_strict(data).ok()?;
+    let stripped = strip_content_comments(data);
+    let content = Content::decode_strict(stripped.as_ref()).ok()?;
     let mut used = UsedNames::default();
     let mut last_name: Option<&[u8]> = None;
 
@@ -243,6 +245,111 @@ fn scan_names(data: &[u8]) -> Option<UsedNames> {
     }
 
     Some(used)
+}
+
+fn strip_content_comments(data: &[u8]) -> Cow<'_, [u8]> {
+    let mut stripped: Option<Vec<u8>> = None;
+    let mut i = 0;
+    let mut literal_depth = 0usize;
+    let mut in_hex_string = false;
+
+    while i < data.len() {
+        let byte = data[i];
+
+        if literal_depth > 0 {
+            if let Some(output) = stripped.as_mut() {
+                output.push(byte);
+            }
+            match byte {
+                b'\\' => {
+                    i += 1;
+                    if i < data.len() {
+                        if let Some(output) = stripped.as_mut() {
+                            output.push(data[i]);
+                        }
+                        i += 1;
+                    }
+                }
+                b'(' => {
+                    literal_depth += 1;
+                    i += 1;
+                }
+                b')' => {
+                    literal_depth -= 1;
+                    i += 1;
+                }
+                _ => i += 1,
+            }
+            continue;
+        }
+
+        if in_hex_string {
+            if let Some(output) = stripped.as_mut() {
+                output.push(byte);
+            }
+            if byte == b'>' {
+                in_hex_string = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        match byte {
+            b'%' => {
+                let output = stripped.get_or_insert_with(|| data[..i].to_vec());
+                output.push(b' ');
+                i += 1;
+                while i < data.len() && data[i] != b'\r' && data[i] != b'\n' {
+                    i += 1;
+                }
+                if i < data.len() {
+                    output.push(data[i]);
+                    if data[i] == b'\r' && i + 1 < data.len() && data[i + 1] == b'\n' {
+                        i += 1;
+                        output.push(data[i]);
+                    }
+                    i += 1;
+                }
+            }
+            b'(' => {
+                if let Some(output) = stripped.as_mut() {
+                    output.push(byte);
+                }
+                literal_depth = 1;
+                i += 1;
+            }
+            b'<' if data.get(i + 1) == Some(&b'<') => {
+                if let Some(output) = stripped.as_mut() {
+                    output.extend_from_slice(b"<<");
+                }
+                i += 2;
+            }
+            b'<' if data.get(i + 1) != Some(&b'<') => {
+                if let Some(output) = stripped.as_mut() {
+                    output.push(byte);
+                }
+                in_hex_string = true;
+                i += 1;
+            }
+            b'>' if data.get(i + 1) == Some(&b'>') => {
+                if let Some(output) = stripped.as_mut() {
+                    output.extend_from_slice(b">>");
+                }
+                i += 2;
+            }
+            _ => {
+                if let Some(output) = stripped.as_mut() {
+                    output.push(byte);
+                }
+                i += 1;
+            }
+        }
+    }
+
+    match stripped {
+        Some(stripped) => Cow::Owned(stripped),
+        None => Cow::Borrowed(data),
+    }
 }
 
 fn scan_names_cached(
@@ -474,5 +581,32 @@ mod tests {
     #[test]
     fn strict_scan_rejects_trailing_invalid_content() {
         assert!(scan_names(b"/TPL0 Do @@@").is_none());
+    }
+
+    #[test]
+    fn scan_tolerates_content_stream_comments() {
+        let used = scan_names(b"q /TPL0 Do\n% producer comment\nBT /F1 12 Tf ET Q").unwrap();
+
+        assert!(used.contains(b"TPL0"));
+        assert!(used.contains(b"F1"));
+    }
+
+    #[test]
+    fn scan_preserves_percent_inside_literal_strings() {
+        let used = scan_names(b"(% not a comment) Tj /TPL0 Do").unwrap();
+
+        assert!(used.contains(b"TPL0"));
+    }
+
+    #[test]
+    fn scan_preserves_percent_inside_hex_strings() {
+        assert!(scan_names(b"<% not a comment\n> /TPL0 Do").is_none());
+    }
+
+    #[test]
+    fn scan_strips_comments_after_inline_dictionaries() {
+        let used = scan_names(b"<< /MCID 0 >> BDC % producer comment\n/TPL0 Do EMC").unwrap();
+
+        assert!(used.contains(b"TPL0"));
     }
 }

--- a/src/split.rs
+++ b/src/split.rs
@@ -1,6 +1,10 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Mutex,
+    },
 };
 
 use lopdf::{dictionary, Document, Object};
@@ -64,7 +68,7 @@ pub fn split_with_password(
             let pages: BTreeMap<u32, lopdf::ObjectId> = (1u32..).zip(ordered_pages).collect();
             let resolved_outputs = resolve_split_outputs(outputs, &pages, true)?;
             reject_duplicate_output_paths(&resolved_outputs)?;
-            run_split_outputs(source, &resolved_outputs)
+            with_prune_fallback_report(|| run_split_outputs(source, &resolved_outputs))
         });
     }
 
@@ -108,7 +112,7 @@ pub fn split_with_password(
     }
     let resolved_outputs = resolve_split_outputs(outputs, &pages, false)?;
     reject_duplicate_output_paths(&resolved_outputs)?;
-    run_split_outputs(&source, &resolved_outputs)
+    with_prune_fallback_report(|| run_split_outputs(&source, &resolved_outputs))
 }
 
 /// Unbounded split through the lazy source: the fallback when the eager
@@ -124,7 +128,7 @@ fn split_via_lazy(input: &Path, password: Option<&str>, outputs: &[SplitOutput])
         let pages: BTreeMap<u32, lopdf::ObjectId> = (1u32..).zip(ordered_pages).collect();
         let resolved_outputs = resolve_split_outputs(outputs, &pages, false)?;
         reject_duplicate_output_paths(&resolved_outputs)?;
-        run_split_outputs(source, &resolved_outputs)
+        with_prune_fallback_report(|| run_split_outputs(source, &resolved_outputs))
     })
 }
 
@@ -259,19 +263,51 @@ pub fn split_pages_with_options(
         // page once, then emit only page-specific objects per output. Falls
         // back to the generic per-output Document path whenever the template
         // cannot be prepared.
-        if options.pages_per_file == 1 {
-            if let Some(template) = SinglePageTemplate::prepare(source, &pages) {
-                return run_template_outputs(source, &template, &resolved_outputs);
+        with_prune_fallback_report(|| {
+            if options.pages_per_file == 1 {
+                if let Some(template) = SinglePageTemplate::prepare(source, &pages) {
+                    return run_template_outputs(source, &template, &resolved_outputs);
+                }
             }
-        }
 
-        run_split_outputs(source, &resolved_outputs)
+            run_split_outputs(source, &resolved_outputs)
+        })
     })
+}
+
+fn with_prune_fallback_report<T>(operation: impl FnOnce() -> Result<T>) -> Result<T> {
+    if std::env::var_os("PDQ_TIMING").is_none() {
+        return operation();
+    }
+
+    let _report_lock = RESOURCE_PRUNE_FALLBACK_REPORT
+        .lock()
+        .expect("resource prune fallback report mutex poisoned");
+    let start = resource_prune_fallback_count();
+    let result = operation();
+    let fallback_count = resource_prune_fallback_count().saturating_sub(start);
+    if fallback_count > 0 {
+        eprintln!(
+            "pdq: warning: resource pruning fallback used for {fallback_count} page resource \
+             dictionaries; outputs may include unreferenced resources"
+        );
+    }
+    result
 }
 
 /// Concurrent output-file writes allowed during a template split; see
 /// [`WriteGate`] for why this is small.
 const MAX_CONCURRENT_SPLIT_WRITES: usize = 4;
+static RESOURCE_PRUNE_FALLBACKS: AtomicUsize = AtomicUsize::new(0);
+static RESOURCE_PRUNE_FALLBACK_REPORT: Mutex<()> = Mutex::new(());
+
+pub(crate) fn record_resource_prune_fallback() {
+    RESOURCE_PRUNE_FALLBACKS.fetch_add(1, Ordering::Relaxed);
+}
+
+fn resource_prune_fallback_count() -> usize {
+    RESOURCE_PRUNE_FALLBACKS.load(Ordering::Relaxed)
+}
 
 fn run_template_outputs(
     source: &(impl ObjectSource + Sync),

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use assert_cmd::Command;
-use lopdf::Document;
+use lopdf::{dictionary, Dictionary, Document, Object, Stream};
 use predicates::prelude::*;
 use tempfile::tempdir;
 
@@ -409,6 +409,32 @@ fn split_pages_cli_chunks_and_decrypts_with_password() {
 }
 
 #[test]
+fn split_pages_cli_reports_prune_fallback_when_timing_is_enabled() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("malformed-content.pdf");
+    write_prune_fallback_fixture(&input);
+
+    pdq()
+        .arg("split-pages")
+        .arg(&input)
+        .arg("--output")
+        .arg(temp.path().join("quiet-%d.pdf"))
+        .assert()
+        .success()
+        .stderr("");
+
+    pdq()
+        .env("PDQ_TIMING", "1")
+        .arg("split-pages")
+        .arg(&input)
+        .arg("--output")
+        .arg(temp.path().join("fallback-%d.pdf"))
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("resource pruning fallback used"));
+}
+
+#[test]
 fn split_pages_cli_rejects_zero_pages_per_file() {
     let temp = tempdir().unwrap();
 
@@ -441,4 +467,76 @@ fn cli_help_lists_subcommands() {
             .and(predicate::str::contains("split-pages"))
             .and(predicate::str::contains("merge")),
     );
+}
+
+fn write_prune_fallback_fixture(path: &Path) {
+    let mut document = Document::with_version("1.7");
+    let catalog_id = document.new_object_id();
+    let pages_id = document.new_object_id();
+    let resources_id = document.new_object_id();
+    let page_id = document.new_object_id();
+    let content_id = document.new_object_id();
+    let mut xobjects = Dictionary::new();
+
+    document.objects.insert(
+        catalog_id,
+        dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        }
+        .into(),
+    );
+    document.objects.insert(
+        pages_id,
+        dictionary! {
+            "Type" => "Pages",
+            "Kids" => Object::Array(vec![Object::Reference(page_id)]),
+            "Count" => 1,
+        }
+        .into(),
+    );
+
+    for index in 0..7 {
+        let form_id = document.new_object_id();
+        xobjects.set(format!("X{index}"), form_id);
+        document.objects.insert(
+            form_id,
+            Object::Stream(Stream::new(
+                dictionary! {
+                    "Type" => "XObject",
+                    "Subtype" => "Form",
+                    "BBox" => Object::Array(vec![0.into(), 0.into(), 10.into(), 10.into()]),
+                    "Resources" => dictionary! {},
+                },
+                b"q Q".to_vec(),
+            )),
+        );
+    }
+
+    document.objects.insert(
+        resources_id,
+        dictionary! {
+            "XObject" => Object::Dictionary(xobjects),
+        }
+        .into(),
+    );
+    document.objects.insert(
+        content_id,
+        Object::Stream(Stream::new(Dictionary::new(), b"q /X0 Do @@@ Q".to_vec())),
+    );
+    document.objects.insert(
+        page_id,
+        dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "MediaBox" => Object::Array(vec![0.into(), 0.into(), 100.into(), 100.into()]),
+            "Resources" => resources_id,
+            "Contents" => content_id,
+        }
+        .into(),
+    );
+    document.trailer.set("Root", catalog_id);
+    document
+        .save(path)
+        .unwrap_or_else(|err| panic!("failed to save prune-fallback fixture: {err}"));
 }

--- a/tests/real_world.rs
+++ b/tests/real_world.rs
@@ -1198,9 +1198,9 @@ fn page_count_rejects_direct_page_tree_kids() {
 }
 
 #[test]
-fn trf4_like_with_content_comments_still_splits_into_valid_pages() {
-    // % comments in content streams defeat strict content parsing, which
-    // disables resource pruning; outputs get bigger but must stay correct
+fn trf4_like_with_content_comments_still_prunes_shared_resources() {
+    // % comments are legal in content streams and must not disable resource
+    // pruning; each output should keep only the form it actually draws.
     let temp = tempdir().unwrap();
     let input = temp.path().join("trf4-like-comments.pdf");
     build_trf4_like(&input, TRF4_PAGES, true);
@@ -1212,10 +1212,27 @@ fn trf4_like_with_content_comments_still_splits_into_valid_pages() {
     let outputs: Vec<_> = fs::read_dir(&out_dir).unwrap().collect();
     assert_eq!(outputs.len(), TRF4_PAGES);
 
+    let input_len = fs::metadata(&input).unwrap().len();
     let qpdf = QpdfValidator::detect();
-    for page in [1, TRF4_PAGES] {
+    for page in [1, 30, TRF4_PAGES] {
         let path = out_dir.join(split_page_name(page, TRF4_PAGES));
-        assert_eq!(Document::load(&path).unwrap().get_pages().len(), 1);
+        let document = Document::load(&path).unwrap();
+        let names = page_xobject_names(&document, single_page_id(&document));
+        assert_eq!(
+            names,
+            vec![format!("TPL{}", page - 1)],
+            "page {page} must keep only its own template after pruning"
+        );
         qpdf.validate(&path, 1);
     }
+
+    let mut largest = 0;
+    for entry in fs::read_dir(&out_dir).unwrap() {
+        largest = largest.max(fs::metadata(entry.unwrap().path()).unwrap().len());
+    }
+    assert!(
+        largest < input_len / 3,
+        "single-page output of {largest} bytes suggests comment-bearing \
+         content disabled resource pruning (input is {input_len} bytes)"
+    );
 }


### PR DESCRIPTION
## Summary
- Strip legal `%` comments outside literal and hex strings before strict content scanning.
- Keep resource pruning active for comment-bearing page streams.
- Count pruning fallbacks and surface a warning under `PDQ_TIMING=1` without changing normal output.

Fixes #11.

## Stack
Base branch: `hcunha/page-tree-cycle-detection` (#10).

## Validation
- `cargo test --lib scan_`
- `cargo test --test cli split_pages_cli_reports_prune_fallback_when_timing_is_enabled`
- `cargo test --test real_world trf4_like_with_content_comments_still_prunes_shared_resources`
- `cargo test --test real_world trf4_like_split_pages_prunes_the_shared_resource_dictionary`
- `cargo test --test split_merge split_pages_falls_back_when_content_stream_is_malformed`
- `cargo test --test split_merge split_pages_prunes_shared_page_resources`
- `cargo check --all-targets`
- `git diff --check`
