### PR TITLE
perf(render): carry hayro-interpret patch memoizing tint-transform evaluation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,18 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Refuse to publish while carrying a [patch.crates-io] override
+        # cargo silently strips [patch] tables when packaging, so the
+        # published crate would build against the unpatched dependency
+        # and lose the fix the patch carries. Fail loudly instead.
+        run: |
+          if grep -q '^\[patch\.crates-io\]' Cargo.toml; then
+            echo "Cargo.toml carries a [patch.crates-io] override; the" >&2
+            echo "published crate would silently drop it. Upstream the" >&2
+            echo "patched dependency before publishing to crates.io." >&2
+            exit 1
+          fi
+
       - name: Check if version is already on crates.io
         id: check
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,8 +710,7 @@ checksum = "9f4d0e94ddd48749f06bbe4e5389fb9799a0c45bcaf00495042076ef05e3241a"
 [[package]]
 name = "hayro-cmap"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d285dc30731c8485de5fa732fbdf2b3affdf01e4da7c2135022ca6fa664bf6"
+source = "git+https://github.com/henrycunh/hayro?branch=tint-transform-lut-0.7#c0612e9b8ab7aff164166aabbad175a6c150c6de"
 dependencies = [
  "brotli",
  "hayro-postscript",
@@ -720,8 +719,7 @@ dependencies = [
 [[package]]
 name = "hayro-interpret"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2613d0406898995042d0794c4245b2f2fba1246490c8ac593769bba6551129d"
+source = "git+https://github.com/henrycunh/hayro?branch=tint-transform-lut-0.7#c0612e9b8ab7aff164166aabbad175a6c150c6de"
 dependencies = [
  "bitflags 2.13.0",
  "hayro-cmap",
@@ -758,8 +756,7 @@ dependencies = [
 [[package]]
 name = "hayro-postscript"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "885c5ef0654933139a9b9546fc2c69e18d37f38aa2520f079092b1be18f1fcaa"
+source = "git+https://github.com/henrycunh/hayro?branch=tint-transform-lut-0.7#c0612e9b8ab7aff164166aabbad175a6c150c6de"
 
 [[package]]
 name = "hayro-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,10 @@ assert_cmd = "2.1.1"
 flate2 = "1.0"
 predicates = "3.1.3"
 tempfile = "3.23.0"
+
+# Carry a patched hayro-interpret until the tint-transform memoization
+# lands upstream (see issue #30): Separation/DeviceN color conversion
+# re-ran the (PostScript) tint transform once per image pixel.
+# Fork branch: tint-transform-lut-0.7 (based on hayro-interpret-v0.7.0).
+[patch.crates-io]
+hayro-interpret = { git = "https://github.com/henrycunh/hayro", branch = "tint-transform-lut-0.7" }


### PR DESCRIPTION
## Summary

Fixes #30.

The slow page in the issue's repro is not font loading: profiling showed all the time in `hayro_interpret::function::type4::eval_inner`. Page 2 contains a 3009×4301 JPEG in a `/DeviceN [/Black]` color space whose tint transform is a Type 4 (PostScript calculator) function, and hayro-interpret 0.7.0 runs that PostScript interpreter **once per pixel** (~12.9M evaluations) in `Separation`/`DeviceN::convert_f32`. That's why the cost was flat across dpi — the image's native sample count is fixed.

Image samples are quantized (8/16 bpc), so there are at most 2^16 distinct inputs. The fix memoizes tint-transform evaluations (last-value fast path + sorted lookup table for single-component inputs; tuple-keyed map for multi-component DeviceN).

## Timings (repro PDF, page 2, `--dpi 126`, M-series)

| build | wall time |
|---|---|
| pdq 0.3.0 (crates.io hayro) | 3.1s (issue reports 4.7s) |
| this branch | **0.34s** |

Output PNG is byte-identical. Page 1 renders in 0.37s, so the slow page is no longer an outlier. Full test suite passes.

## How it's carried

`[patch.crates-io]` pointing `hayro-interpret` at a fork branch (`henrycunh/hayro#tint-transform-lut-0.7`) based on the `hayro-interpret-v0.7.0` tag, with one extra commit repointing its `hayro-syntax` dep to crates.io so the resolved dependency graph matches the unpatched build. The patch should be dropped once the fix is upstreamed (PR to LaurenzV/hayro coming next).