### PR TITLE
feat(dimensions): native per-page geometry without rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ pdq split input.pdf --out 1-3 intro.pdf --out 4-z rest.pdf
 # Concatenate files
 pdq merge --output merged.pdf a.pdf b.pdf c.pdf
 
+# Every page's size and rotation as JSON, without rendering
+pdq dimensions input.pdf
+
 # Rasterize to PNG at 300 DPI
 pdq render --output 'page-%d.png' --dpi 300 --pages 1-10 input.pdf
 ```
@@ -150,6 +153,32 @@ negative, or implausibly large.
 Pass `--strict` to force the validated walk: it counts the exact leaf pages
 `split`/`split-pages` would resolve and is immune to lying metadata.
 
+### `pdq dimensions` — per-page geometry without rendering
+
+```sh
+pdq dimensions [--password PW] input.pdf
+```
+
+Prints every page's size and rotation as JSON on stdout, straight from the
+page tree — no rasterization, so it stays a cheap metadata walk even on very
+large documents:
+
+```json
+{"pages":2,"page_sizes":[{"width":419,"height":595,"rotation":0},{"width":340,"height":680,"rotation":90}]}
+```
+
+`width`/`height` are in PDF points (1/72 inch) with `/Rotate` already
+applied — a page rotated 90 or 270 reports swapped width and height — and
+the effective box is CropBox intersected with MediaBox, exactly the geometry
+`render` uses. That makes the numbers safe to lay out a viewer before any
+page is rendered: a render at `DPI` produces an image of
+`floor(width × DPI/72)` × `floor(height × DPI/72)` pixels. `rotation` is
+normalized to 0, 90, 180, or 270.
+
+Mixed-size documents report each page's true size, and per-page damage
+degrades gracefully: a missing or malformed box falls back to the inherited
+value, then to A4; a malformed `/Rotate` falls back to 0.
+
 ### `pdq render` — rasterize to PNG
 
 ```sh
@@ -192,8 +221,9 @@ outputs are always written unencrypted.
 Files encrypted with only an owner password — the overwhelmingly common
 "permissions" encryption — open with no flags at all, because the empty user
 password is tried first. Files that require a real password take
-`--password` on `split`, `split-pages`, `merge`, and `page-count`; a wrong
-password is reported as exactly that, not as a parse failure.
+`--password` on `split`, `split-pages`, `merge`, `page-count`, and
+`dimensions`; a wrong password is reported as exactly that, not as a parse
+failure.
 
 ## Damaged PDFs
 
@@ -340,6 +370,11 @@ fn main() -> pdq::Result<()> {
     // pdq::page_count is the validated page-tree walk.
     let pages = pdq::page_count_fast(Path::new("big.pdf"))?;
     println!("{pages} pages");
+
+    // Per-page size (points) and rotation, without rendering.
+    for page in pdq::page_dimensions(Path::new("big.pdf"))? {
+        println!("{} x {} pt", page.width, page.height);
+    }
 
     // Extract two ranges in one pass over the input.
     pdq::split(

--- a/README.md
+++ b/README.md
@@ -171,9 +171,14 @@ large documents:
 applied — a page rotated 90 or 270 reports swapped width and height — and
 the effective box is CropBox intersected with MediaBox, exactly the geometry
 `render` uses. That makes the numbers safe to lay out a viewer before any
-page is rendered: a render at `DPI` produces an image of
-`floor(width × DPI/72)` × `floor(height × DPI/72)` pixels. `rotation` is
-normalized to 0, 90, 180, or 270.
+page is rendered: a render at `DPI` produces an image of exactly
+`floor(width × (DPI/72))` × `floor(height × (DPI/72))` pixels, both steps
+computed in single-precision (f32) arithmetic — in JavaScript,
+`Math.floor(Math.fround(width * Math.fround(dpi / 72)))`. The precision
+matters: the same formula in doubles predicts 1px too many on one axis at
+some DPIs — on a US Letter page at 150, 200, or 300 DPI (612×792 pt at
+150 DPI really renders 1275×1649, not the 1275×1650 doubles suggest).
+`rotation` is normalized to 0, 90, 180, or 270.
 
 Mixed-size documents report each page's true size, and per-page damage
 degrades gracefully: a missing or malformed box falls back to the inherited

--- a/src/bin/pdq.rs
+++ b/src/bin/pdq.rs
@@ -3,8 +3,8 @@ use std::{path::PathBuf, process::ExitCode};
 use clap::{Args, Parser, Subcommand};
 use pdq::{
     merge_with_options, page_count_fast_with_password, page_count_with_password,
-    split_pages_with_options, split_with_password, MergeInput, MergeOptions, PageRangeGroup,
-    SplitOutput, SplitPagesOptions,
+    page_dimensions_with_password, split_pages_with_options, split_with_password, MergeInput,
+    MergeOptions, PageRangeGroup, SplitOutput, SplitPagesOptions,
 };
 
 #[derive(Debug, Parser)]
@@ -22,6 +22,8 @@ enum Command {
     Merge(MergeArgs),
     /// Print the number of pages (trusts the root /Count like qpdf; --strict walks the page tree)
     PageCount(PageCountArgs),
+    /// Print each page's size in PDF points and rotation as JSON, without rendering
+    Dimensions(DimensionsArgs),
     #[cfg(feature = "render")]
     Render(RenderArgs),
 }
@@ -81,6 +83,15 @@ struct PageCountArgs {
     /// implausible /Count already falls back to this walk automatically)
     #[arg(long)]
     strict: bool,
+
+    /// Password for encrypted inputs
+    #[arg(long, value_name = "PASSWORD")]
+    password: Option<String>,
+}
+
+#[derive(Debug, Args)]
+struct DimensionsArgs {
+    input: PathBuf,
 
     /// Password for encrypted inputs
     #[arg(long, value_name = "PASSWORD")]
@@ -151,6 +162,10 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             };
             println!("{count}");
         }
+        Command::Dimensions(args) => {
+            let pages = page_dimensions_with_password(&args.input, args.password.as_deref())?;
+            println!("{}", dimensions_json(&pages));
+        }
         #[cfg(feature = "render")]
         Command::Render(args) => {
             let options = pdq::RenderOptions {
@@ -178,4 +193,23 @@ fn parse_split_outputs(
 
 fn parse_merge_inputs(paths: Vec<PathBuf>) -> Vec<MergeInput> {
     paths.into_iter().map(MergeInput::all).collect()
+}
+
+fn dimensions_json(pages: &[pdq::PageDimensions]) -> String {
+    use std::fmt::Write;
+
+    let mut json = format!("{{\"pages\":{},\"page_sizes\":[", pages.len());
+    for (index, page) in pages.iter().enumerate() {
+        if index > 0 {
+            json.push(',');
+        }
+        write!(
+            json,
+            "{{\"width\":{},\"height\":{},\"rotation\":{}}}",
+            page.width, page.height, page.rotation
+        )
+        .expect("writing to a String cannot fail");
+    }
+    json.push_str("]}");
+    json
 }

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -1,0 +1,292 @@
+use std::{collections::BTreeMap, path::Path};
+
+use lopdf::{Object, ObjectId};
+
+use crate::{
+    copy::ObjectSource, lazy::PdfSource, load::map_file, repair::with_repair_retry, Result,
+};
+
+/// Longest reference chain followed when dereferencing an attribute value,
+/// and deepest `/Parent` chain followed when resolving inherited attributes.
+/// Both match the page-tree depth cap in `lazy::walk_pages_until`.
+const MAX_CHAIN: usize = 256;
+
+const POINTS_PER_MM: f64 = 1.0 / (10.0 * 2.54) * 72.0;
+/// Fallback page size when no `MediaBox` resolves, matching hayro's default
+/// so `dimensions` and `render` agree on damaged documents.
+const A4: Rect = Rect {
+    x0: 0.0,
+    y0: 0.0,
+    x1: 210.0 * POINTS_PER_MM,
+    y1: 297.0 * POINTS_PER_MM,
+};
+/// hayro's `SCALAR_NEARLY_ZERO`: boxes this thin fall back to A4 there, so
+/// they must fall back here too.
+const NEARLY_ZERO: f32 = 1.0 / (1 << 12) as f32;
+
+/// The rendered geometry of one page: the effective box size in PDF points
+/// with `/Rotate` already applied, plus the normalized rotation itself.
+///
+/// `width`/`height` equal hayro's `Page::render_dimensions`, so a render at
+/// `dpi` produces a `floor(width * dpi / 72)` × `floor(height * dpi / 72)`
+/// pixel image of the page.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PageDimensions {
+    /// Visible width in PDF points (already swapped with `height` when the
+    /// page is rotated 90 or 270 degrees).
+    pub width: f32,
+    /// Visible height in PDF points.
+    pub height: f32,
+    /// Normalized page rotation: 0, 90, 180, or 270.
+    pub rotation: u16,
+}
+
+/// Report every page's size (PDF points) and rotation straight from the page
+/// tree — no rasterization.
+///
+/// Uses the same lazy, mmap-backed reader and page-tree walk as `page-count`,
+/// so the page list can never disagree with the pages `split`/`render` would
+/// resolve, and the whole call stays a metadata walk: content streams are
+/// never touched. The effective box is CropBox intersected with MediaBox
+/// (CropBox defaulting to MediaBox), `/Rotate` of 90/270 swaps width and
+/// height, and both attributes are resolved through page-tree inheritance —
+/// exactly the geometry hayro uses for `render`, so `width * dpi / 72`
+/// (floored) is the pixel width `render` produces at `dpi`.
+///
+/// Damage is tolerated per page rather than failing the document: a missing
+/// or malformed box falls back to the inherited value, then A4; a missing or
+/// malformed `/Rotate` falls back to 0. Encrypted PDFs with an empty user
+/// password are decrypted transparently; files that need a real password
+/// require [`page_dimensions_with_password`].
+pub fn page_dimensions(input: &Path) -> Result<Vec<PageDimensions>> {
+    page_dimensions_with_password(input, None)
+}
+
+/// Like [`page_dimensions`], additionally decrypting encrypted inputs with
+/// `password` when the empty user password does not authenticate.
+pub fn page_dimensions_with_password(
+    input: &Path,
+    password: Option<&str>,
+) -> Result<Vec<PageDimensions>> {
+    let timing = std::env::var_os("PDQ_TIMING").is_some();
+    let start = std::time::Instant::now();
+    let mmap = map_file(input)?;
+    // Damaged inputs whose xref lies about offsets get one retry against a
+    // reconstructed table; the closure re-runs (and re-logs) in that case.
+    with_repair_retry(&mmap, input, password, |source| {
+        if timing {
+            eprintln!("phase parse: {:?}", start.elapsed());
+        }
+        let walk_start = std::time::Instant::now();
+        let dimensions = dimensions_impl(source)?;
+        if timing {
+            eprintln!("phase walk: {:?}", walk_start.elapsed());
+        }
+        Ok(dimensions)
+    })
+}
+
+fn dimensions_impl(source: &PdfSource) -> Result<Vec<PageDimensions>> {
+    let page_ids = source.page_ids()?;
+    let mut nodes = NodeCache::default();
+    Ok(page_ids
+        .into_iter()
+        .map(|id| resolve_page(source, &mut nodes, id))
+        .collect())
+}
+
+/// Per-node geometry attributes, cached so shared ancestors are parsed once.
+/// `None` values mean the attribute is absent or malformed at this node — in
+/// both cases resolution continues up the `/Parent` chain, matching hayro's
+/// leniency.
+#[derive(Debug, Clone, Copy)]
+struct NodeGeometry {
+    media_box: Option<Rect>,
+    crop_box: Option<Rect>,
+    rotate: Option<i64>,
+    parent: Option<ObjectId>,
+}
+
+#[derive(Default)]
+struct NodeCache(BTreeMap<ObjectId, Option<NodeGeometry>>);
+
+impl NodeCache {
+    fn get(&mut self, source: &PdfSource, id: ObjectId) -> Option<NodeGeometry> {
+        if let Some(cached) = self.0.get(&id) {
+            return *cached;
+        }
+        let geometry = node_geometry(source, id);
+        self.0.insert(id, geometry);
+        geometry
+    }
+}
+
+fn node_geometry(source: &PdfSource, id: ObjectId) -> Option<NodeGeometry> {
+    let object = source.get_object_value(id).ok()?;
+    let dict = object.as_dict().ok()?;
+    Some(NodeGeometry {
+        media_box: dict.get(b"MediaBox").ok().and_then(|v| rect(source, v)),
+        crop_box: dict.get(b"CropBox").ok().and_then(|v| rect(source, v)),
+        rotate: dict.get(b"Rotate").ok().and_then(|v| integer(source, v)),
+        parent: match dict.get(b"Parent") {
+            Ok(Object::Reference(parent)) => Some(*parent),
+            _ => None,
+        },
+    })
+}
+
+/// Resolve one page's geometry, walking up the `/Parent` chain for inherited
+/// attributes. Any damage along the way (missing node, cycle, broken parent
+/// link) just stops the chain and the defaults apply — a single bad page must
+/// not fail the document.
+fn resolve_page(source: &PdfSource, nodes: &mut NodeCache, page_id: ObjectId) -> PageDimensions {
+    let mut media_box = None;
+    let mut crop_box = None;
+    let mut rotate = None;
+
+    let mut current = Some(page_id);
+    let mut hops = 0usize;
+    while let Some(id) = current {
+        hops += 1;
+        if hops > MAX_CHAIN {
+            break;
+        }
+        let Some(node) = nodes.get(source, id) else {
+            break;
+        };
+        media_box = media_box.or(node.media_box);
+        crop_box = crop_box.or(node.crop_box);
+        rotate = rotate.or(node.rotate);
+        if media_box.is_some() && crop_box.is_some() && rotate.is_some() {
+            break;
+        }
+        // A parent pointing back down the chain would loop; the hop cap
+        // bounds it, and revisiting cached nodes costs nothing.
+        current = node.parent;
+    }
+
+    // From here on this mirrors hayro's `Page::base_dimensions` /
+    // `render_dimensions` exactly — including the f64→f32 casts — so the
+    // reported size floors to the same pixel size `render` produces.
+    let media_box = media_box.unwrap_or(A4);
+    let effective = crop_box.unwrap_or(media_box).intersect(media_box);
+    let (mut width, mut height) = if (effective.width() as f32).abs() <= NEARLY_ZERO
+        || (effective.height() as f32).abs() <= NEARLY_ZERO
+    {
+        (A4.width() as f32, A4.height() as f32)
+    } else {
+        (
+            effective.width().max(1.0) as f32,
+            effective.height().max(1.0) as f32,
+        )
+    };
+
+    // Coordinates big enough to overflow f32 parse as infinity; `render`
+    // refuses such pages ("too large to render"), so there is no pixel size
+    // to agree with — fall back to A4 rather than emit non-JSON `inf`.
+    if !width.is_finite() || !height.is_finite() {
+        (width, height) = (A4.width() as f32, A4.height() as f32);
+    }
+
+    let rotation = match rotate.unwrap_or(0).rem_euclid(360) {
+        90 => 90,
+        180 => 180,
+        270 => 270,
+        // Anything that is not a right angle renders unrotated.
+        _ => 0,
+    };
+    if rotation == 90 || rotation == 270 {
+        std::mem::swap(&mut width, &mut height);
+    }
+
+    PageDimensions {
+        width,
+        height,
+        rotation,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Rect {
+    x0: f64,
+    y0: f64,
+    x1: f64,
+    y1: f64,
+}
+
+impl Rect {
+    fn intersect(&self, other: Rect) -> Rect {
+        let x0 = self.x0.max(other.x0);
+        let y0 = self.y0.max(other.y0);
+        let x1 = self.x1.min(other.x1);
+        let y1 = self.y1.min(other.y1);
+        Rect {
+            x0,
+            y0,
+            x1: x1.max(x0),
+            y1: y1.max(y0),
+        }
+    }
+
+    fn width(&self) -> f64 {
+        self.x1 - self.x0
+    }
+
+    fn height(&self) -> f64 {
+        self.y1 - self.y0
+    }
+}
+
+/// Parse a PDF rectangle, tolerating indirect references at both the array
+/// and the coordinate level. Coordinates go through f32 like hayro's reader,
+/// keeping the arithmetic bit-identical with `render`. The first four
+/// elements must all be numeric — a malformed element rejects the whole
+/// rectangle (hayro stops at it too) instead of shifting later coordinates
+/// into its slot.
+fn rect(source: &PdfSource, object: &Object) -> Option<Rect> {
+    let object = dereference(source, object)?;
+    let array = object.as_array().ok()?;
+    let mut coords = array.iter().map(|value| number(source, value));
+    let x0 = coords.next()?? as f64;
+    let y0 = coords.next()?? as f64;
+    let x1 = coords.next()?? as f64;
+    let y1 = coords.next()?? as f64;
+    Some(Rect {
+        x0: x0.min(x1),
+        y0: y0.min(y1),
+        x1: x1.max(x0),
+        y1: y1.max(y0),
+    })
+}
+
+fn number(source: &PdfSource, object: &Object) -> Option<f32> {
+    match dereference(source, object)? {
+        Object::Integer(value) => Some(value as f32),
+        Object::Real(value) => Some(value),
+        _ => None,
+    }
+}
+
+fn integer(source: &PdfSource, object: &Object) -> Option<i64> {
+    match dereference(source, object)? {
+        Object::Integer(value) => Some(value),
+        // hayro truncates a real /Rotate; keep parity.
+        Object::Real(value) => Some(value as i64),
+        _ => None,
+    }
+}
+
+/// Follow reference chains to a direct object, cloning only when the value
+/// is indirect. `None` on dangling references or reference cycles.
+fn dereference(source: &PdfSource, object: &Object) -> Option<Object> {
+    let mut object = object.clone();
+    let mut hops = 0usize;
+    while let Object::Reference(id) = object {
+        hops += 1;
+        if hops > MAX_CHAIN {
+            return None;
+        }
+        object = source.get_object_value(id).ok()?.into_owned();
+    }
+    Some(object)
+}

--- a/src/dimensions.rs
+++ b/src/dimensions.rs
@@ -28,8 +28,11 @@ const NEARLY_ZERO: f32 = 1.0 / (1 << 12) as f32;
 /// with `/Rotate` already applied, plus the normalized rotation itself.
 ///
 /// `width`/`height` equal hayro's `Page::render_dimensions`, so a render at
-/// `dpi` produces a `floor(width * dpi / 72)` × `floor(height * dpi / 72)`
-/// pixel image of the page.
+/// `dpi` produces a pixel image of exactly
+/// `floor(width * (dpi / 72.0))` × `floor(height * (dpi / 72.0))`, both
+/// steps in `f32` — the same single-precision arithmetic hayro renders
+/// with. Double precision predicts 1px too many at some DPIs (150, 200,
+/// 300 on a 612×792 Letter page).
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct PageDimensions {
     /// Visible width in PDF points (already swapped with `height` when the
@@ -50,8 +53,8 @@ pub struct PageDimensions {
 /// never touched. The effective box is CropBox intersected with MediaBox
 /// (CropBox defaulting to MediaBox), `/Rotate` of 90/270 swaps width and
 /// height, and both attributes are resolved through page-tree inheritance —
-/// exactly the geometry hayro uses for `render`, so `width * dpi / 72`
-/// (floored) is the pixel width `render` produces at `dpi`.
+/// exactly the geometry hayro uses for `render`, so `width * (dpi / 72.0)`
+/// in `f32`, floored, is the pixel width `render` produces at `dpi`.
 ///
 /// Damage is tolerated per page rather than failing the document: a missing
 /// or malformed box falls back to the inherited value, then A4; a missing or

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod copy;
 pub mod count;
+pub mod dimensions;
 mod filter;
 pub mod lazy;
 pub mod load;
@@ -18,6 +19,7 @@ pub use copy::{CopyContext, CopyOptions};
 pub use count::{
     page_count, page_count_fast, page_count_fast_with_password, page_count_with_password,
 };
+pub use dimensions::{page_dimensions, page_dimensions_with_password, PageDimensions};
 pub use merge::{merge, merge_with_options, MergeInput, MergeOptions};
 pub use range::{PageRangeError, PageRangeGroup};
 #[cfg(feature = "render")]

--- a/tests/dimensions.rs
+++ b/tests/dimensions.rs
@@ -421,12 +421,13 @@ fn dimensions_cli_requires_password_for_user_password_input() {
 }
 
 /// The acceptance criterion from issue #33: for every page,
-/// `width`/`height` × (dpi/72) must equal the pixel size `pdq render`
-/// produces at that dpi.
+/// `floor(width × (dpi/72))` in f32 — hayro's own arithmetic — must equal
+/// the pixel size `pdq render` produces at that dpi. The DPI set includes
+/// 150, 200, and 300, where f32 and f64 disagree on a 612×792 Letter page.
 #[cfg(feature = "render")]
 #[test]
 fn dimensions_match_render_pixel_sizes() {
-    use pdq::{render_pages, RenderOptions};
+    use pdq::{render_pages, PageRangeGroup, RenderOptions};
 
     let png_dimensions = |path: &Path| {
         let bytes = std::fs::read(path)
@@ -462,24 +463,34 @@ fn dimensions_match_render_pixel_sizes() {
         ],
     );
 
-    for input in [&mixed, &fixture("11-pages.pdf")] {
+    // The Letter fixture renders only page 1 to keep high-dpi renders cheap.
+    let letter = fixture("11-pages.pdf");
+    for (input, range) in [(&mixed, None), (&letter, Some("1"))] {
         let pages = page_dimensions(input).unwrap();
-        for dpi in [72.0f32, 144.0] {
+        let selected: Vec<usize> = match range {
+            Some(_) => vec![1],
+            None => (1..=pages.len()).collect(),
+        };
+        for dpi in [72.0f32, 96.0, 144.0, 150.0, 200.0, 300.0] {
             let out = tempdir().unwrap();
             let pattern = out.path().join("page-%d.png");
             render_pages(
                 input,
                 pattern.to_str().unwrap(),
-                &RenderOptions { dpi, pages: None },
+                &RenderOptions {
+                    dpi,
+                    pages: range.map(|range| PageRangeGroup::parse(range).unwrap()),
+                },
             )
             .unwrap();
 
             let width = pages.len().to_string().len();
-            for (index, page) in pages.iter().enumerate() {
-                let path =
-                    out.path()
-                        .join(format!("page-{:0width$}.png", index + 1, width = width));
+            for &page_number in &selected {
+                let page = &pages[page_number - 1];
+                let path = out.path().join(format!("page-{page_number:0width$}.png"));
                 let (pixel_width, pixel_height) = png_dimensions(&path);
+                // hayro multiplies f32 width by f32 dpi/72 and floors the
+                // (exactly widened) product.
                 let scale = dpi / 72.0;
                 assert_eq!(
                     (pixel_width, pixel_height),
@@ -487,10 +498,13 @@ fn dimensions_match_render_pixel_sizes() {
                         ((page.width * scale) as f64).floor() as u32,
                         ((page.height * scale) as f64).floor() as u32,
                     ),
-                    "page {} of {} at {dpi} dpi",
-                    index + 1,
+                    "page {page_number} of {} at {dpi} dpi",
                     input.display(),
                 );
+                if input == &letter && dpi == 150.0 {
+                    // f64 arithmetic would predict 1275×1650 here.
+                    assert_eq!((pixel_width, pixel_height), (1275, 1649));
+                }
             }
         }
     }

--- a/tests/dimensions.rs
+++ b/tests/dimensions.rs
@@ -1,0 +1,497 @@
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+use lopdf::{dictionary, Dictionary, Document, Object, Stream};
+use pdq::{page_dimensions, page_dimensions_with_password, PageDimensions};
+use predicates::prelude::*;
+use tempfile::tempdir;
+
+const POINTS_PER_MM: f64 = 1.0 / (10.0 * 2.54) * 72.0;
+const A4_WIDTH: f32 = (210.0 * POINTS_PER_MM) as f32;
+const A4_HEIGHT: f32 = (297.0 * POINTS_PER_MM) as f32;
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn pdq() -> Command {
+    Command::cargo_bin("pdq").unwrap()
+}
+
+/// One page description: extra entries merged into the page dictionary.
+fn write_pdf(path: &Path, pages_attrs: Dictionary, page_dicts: Vec<Dictionary>) {
+    let mut document = Document::with_version("1.7");
+    let catalog_id = document.new_object_id();
+    let pages_id = document.new_object_id();
+
+    let kids = page_dicts
+        .into_iter()
+        .map(|extra| {
+            let content_id = document.add_object(Object::Stream(Stream::new(
+                Dictionary::new(),
+                b"q Q".to_vec(),
+            )));
+            let mut page = dictionary! {
+                "Type" => "Page",
+                "Parent" => pages_id,
+                "Resources" => dictionary! {},
+                "Contents" => content_id,
+            };
+            page.extend(&extra);
+            Object::Reference(document.add_object(page))
+        })
+        .collect::<Vec<_>>();
+
+    let mut pages = dictionary! {
+        "Type" => "Pages",
+        "Kids" => Object::Array(kids.clone()),
+        "Count" => kids.len() as i64,
+    };
+    pages.extend(&pages_attrs);
+    document.objects.insert(pages_id, pages.into());
+    document.objects.insert(
+        catalog_id,
+        dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        }
+        .into(),
+    );
+    document.trailer.set("Root", catalog_id);
+    document
+        .save(path)
+        .unwrap_or_else(|err| panic!("failed to save dimensions fixture: {err}"));
+}
+
+/// Write a PDF from raw object bodies (`1 0 obj` onward, `/Root` = object 1)
+/// with a correct xref, for values lopdf's writer cannot round-trip.
+fn write_raw_pdf(path: &Path, bodies: &[String]) {
+    let mut pdf = b"%PDF-1.7\n".to_vec();
+    let mut offsets = Vec::new();
+    for (index, body) in bodies.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{} 0 obj\n{body}\nendobj\n", index + 1).as_bytes());
+    }
+    let xref_offset = pdf.len();
+    pdf.extend_from_slice(
+        format!("xref\n0 {}\n0000000000 65535 f \n", bodies.len() + 1).as_bytes(),
+    );
+    for offset in offsets {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n",
+            bodies.len() + 1
+        )
+        .as_bytes(),
+    );
+    std::fs::write(path, pdf).unwrap();
+}
+
+fn media_box(x0: i64, y0: i64, x1: i64, y1: i64) -> Dictionary {
+    dictionary! {
+        "MediaBox" => Object::Array(vec![x0.into(), y0.into(), x1.into(), y1.into()]),
+    }
+}
+
+#[test]
+fn reports_each_page_size_in_mixed_size_documents() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("mixed.pdf");
+    write_pdf(
+        &input,
+        Dictionary::new(),
+        vec![media_box(0, 0, 419, 595), media_box(0, 0, 340, 680)],
+    );
+
+    let pages = page_dimensions(&input).unwrap();
+    assert_eq!(
+        pages,
+        vec![
+            PageDimensions {
+                width: 419.0,
+                height: 595.0,
+                rotation: 0
+            },
+            PageDimensions {
+                width: 340.0,
+                height: 680.0,
+                rotation: 0
+            },
+        ]
+    );
+}
+
+#[test]
+fn inherits_media_box_and_rotate_from_the_pages_node() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("inherited.pdf");
+    let mut pages_attrs = media_box(0, 0, 200, 400);
+    pages_attrs.set("Rotate", 90);
+    write_pdf(
+        &input,
+        pages_attrs,
+        vec![Dictionary::new(), media_box(0, 0, 300, 500)],
+    );
+
+    let pages = page_dimensions(&input).unwrap();
+    // Page 1 inherits both: 200x400 rotated 90 reports swapped.
+    assert_eq!(
+        pages[0],
+        PageDimensions {
+            width: 400.0,
+            height: 200.0,
+            rotation: 90
+        }
+    );
+    // Page 2 overrides the box but still inherits the rotation.
+    assert_eq!(
+        pages[1],
+        PageDimensions {
+            width: 500.0,
+            height: 300.0,
+            rotation: 90
+        }
+    );
+}
+
+#[test]
+fn crop_box_intersected_with_media_box_wins_over_media_box() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("cropped.pdf");
+    let mut page = media_box(0, 0, 600, 800);
+    // Extends past the media box on the right: the effective width is
+    // clipped to the intersection (600 - 100 = 500).
+    page.set(
+        "CropBox",
+        Object::Array(vec![100.into(), 50.into(), 700.into(), 750.into()]),
+    );
+    write_pdf(&input, Dictionary::new(), vec![page]);
+
+    let pages = page_dimensions(&input).unwrap();
+    assert_eq!(
+        pages,
+        vec![PageDimensions {
+            width: 500.0,
+            height: 700.0,
+            rotation: 0
+        }]
+    );
+}
+
+#[test]
+fn rotation_is_normalized_to_the_visible_orientation() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("rotated.pdf");
+    let rotated = |rotate: i64| {
+        let mut page = media_box(0, 0, 300, 500);
+        page.set("Rotate", rotate);
+        page
+    };
+    write_pdf(
+        &input,
+        Dictionary::new(),
+        vec![
+            rotated(90),
+            rotated(180),
+            rotated(270),
+            rotated(-90),
+            rotated(450),
+            // Not a right angle: renders unrotated.
+            rotated(45),
+        ],
+    );
+
+    let pages = page_dimensions(&input).unwrap();
+    let expect = |width: f32, height: f32, rotation: u16| PageDimensions {
+        width,
+        height,
+        rotation,
+    };
+    assert_eq!(
+        pages,
+        vec![
+            expect(500.0, 300.0, 90),
+            expect(300.0, 500.0, 180),
+            expect(500.0, 300.0, 270),
+            expect(500.0, 300.0, 270),
+            expect(500.0, 300.0, 90),
+            expect(300.0, 500.0, 0),
+        ]
+    );
+}
+
+#[test]
+fn damaged_geometry_falls_back_instead_of_failing() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("damaged.pdf");
+    let mut malformed_box = Dictionary::new();
+    malformed_box.set("MediaBox", Object::Array(vec![0.into(), 0.into()]));
+    let mut malformed_rotate = media_box(0, 0, 300, 500);
+    malformed_rotate.set("Rotate", Object::Name(b"sideways".to_vec()));
+    let mut zero_area = Dictionary::new();
+    zero_area.set(
+        "MediaBox",
+        Object::Array(vec![0.into(), 0.into(), 0.into(), 0.into()]),
+    );
+    let mut junk_element = Dictionary::new();
+    // A non-numeric element must reject the whole box, not shift the later
+    // coordinates into its slot (which would fabricate a 0x800 box here).
+    junk_element.set(
+        "MediaBox",
+        Object::Array(vec![
+            0.into(),
+            Object::Name(b"junk".to_vec()),
+            600.into(),
+            800.into(),
+        ]),
+    );
+    write_pdf(
+        &input,
+        Dictionary::new(),
+        // No MediaBox anywhere, a truncated MediaBox, a malformed /Rotate,
+        // a zero-area box, and a box with a junk element: every page falls
+        // back instead of erroring.
+        vec![
+            Dictionary::new(),
+            malformed_box,
+            malformed_rotate,
+            zero_area,
+            junk_element,
+        ],
+    );
+
+    let pages = page_dimensions(&input).unwrap();
+    let a4 = PageDimensions {
+        width: A4_WIDTH,
+        height: A4_HEIGHT,
+        rotation: 0,
+    };
+    assert_eq!(
+        pages,
+        vec![
+            a4,
+            a4,
+            PageDimensions {
+                width: 300.0,
+                height: 500.0,
+                rotation: 0
+            },
+            a4,
+            a4,
+        ]
+    );
+}
+
+/// A coordinate too large for f32 parses as infinity, which `render` refuses
+/// ("too large to render") and JSON cannot represent — the page falls back
+/// to A4. lopdf cannot round-trip such values, so the file is written raw.
+#[test]
+fn f32_overflowing_box_falls_back_to_a4() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("overflow.pdf");
+    let huge = "9".repeat(40);
+    write_raw_pdf(
+        &input,
+        &[
+            "<< /Type /Catalog /Pages 2 0 R >>".into(),
+            "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".into(),
+            format!("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {huge}.0 100] >>"),
+        ],
+    );
+
+    let pages = page_dimensions(&input).unwrap();
+    assert_eq!(
+        pages,
+        vec![PageDimensions {
+            width: A4_WIDTH,
+            height: A4_HEIGHT,
+            rotation: 0
+        }]
+    );
+}
+
+#[test]
+fn resolves_indirect_media_box_references() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("indirect.pdf");
+    let mut document = Document::with_version("1.7");
+    let catalog_id = document.new_object_id();
+    let pages_id = document.new_object_id();
+    let box_id = document.add_object(Object::Array(vec![
+        0.into(),
+        0.into(),
+        Object::Real(419.5),
+        595.into(),
+    ]));
+    let page_id = document.add_object(dictionary! {
+        "Type" => "Page",
+        "Parent" => pages_id,
+        "MediaBox" => Object::Reference(box_id),
+        "Resources" => dictionary! {},
+    });
+    document.objects.insert(
+        pages_id,
+        dictionary! {
+            "Type" => "Pages",
+            "Kids" => Object::Array(vec![Object::Reference(page_id)]),
+            "Count" => 1,
+        }
+        .into(),
+    );
+    document.objects.insert(
+        catalog_id,
+        dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        }
+        .into(),
+    );
+    document.trailer.set("Root", catalog_id);
+    document.save(&input).unwrap();
+
+    let pages = page_dimensions(&input).unwrap();
+    assert_eq!(
+        pages,
+        vec![PageDimensions {
+            width: 419.5,
+            height: 595.0,
+            rotation: 0
+        }]
+    );
+}
+
+#[test]
+fn reads_encrypted_inputs_like_page_count() {
+    let pages = page_dimensions_with_password(&fixture("user-password.pdf"), Some("user")).unwrap();
+    assert_eq!(pages.len(), 11);
+    assert_eq!(pages[0].width, 612.0);
+    assert_eq!(pages[0].height, 792.0);
+
+    // Owner-only encryption opens with the empty user password.
+    let pages = page_dimensions(&fixture("owner-only.pdf")).unwrap();
+    assert_eq!(pages.len(), 11);
+
+    let error = page_dimensions(&fixture("user-password.pdf")).unwrap_err();
+    assert!(matches!(error, pdq::PdfOpsError::Password(_)));
+}
+
+#[test]
+fn reads_object_stream_page_trees() {
+    let pages = page_dimensions(&fixture("11-pages-objstm.pdf")).unwrap();
+    assert_eq!(pages.len(), 11);
+    assert!(pages
+        .iter()
+        .all(|page| page.width == 612.0 && page.height == 792.0 && page.rotation == 0));
+}
+
+#[test]
+fn dimensions_cli_prints_json() {
+    pdq()
+        .arg("dimensions")
+        .arg(fixture("11-pages.pdf"))
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            r#"{"pages":11,"page_sizes":[{"width":612,"height":792,"rotation":0},"#,
+        ));
+}
+
+#[test]
+fn dimensions_cli_requires_password_for_user_password_input() {
+    pdq()
+        .arg("dimensions")
+        .arg(fixture("user-password.pdf"))
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--password"));
+
+    pdq()
+        .arg("dimensions")
+        .arg(fixture("user-password.pdf"))
+        .arg("--password")
+        .arg("user")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(r#""pages":11"#));
+}
+
+/// The acceptance criterion from issue #33: for every page,
+/// `width`/`height` × (dpi/72) must equal the pixel size `pdq render`
+/// produces at that dpi.
+#[cfg(feature = "render")]
+#[test]
+fn dimensions_match_render_pixel_sizes() {
+    use pdq::{render_pages, RenderOptions};
+
+    let png_dimensions = |path: &Path| {
+        let bytes = std::fs::read(path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+        let width = u32::from_be_bytes(bytes[16..20].try_into().unwrap());
+        let height = u32::from_be_bytes(bytes[20..24].try_into().unwrap());
+        (width, height)
+    };
+
+    let temp = tempdir().unwrap();
+    let mixed = temp.path().join("mixed.pdf");
+    let mut rotated = media_box(0, 0, 340, 680);
+    rotated.set("Rotate", 270);
+    let mut cropped = media_box(0, 0, 600, 800);
+    cropped.set(
+        "CropBox",
+        Object::Array(vec![
+            Object::Real(10.25),
+            0.into(),
+            Object::Real(419.75),
+            595.into(),
+        ]),
+    );
+    write_pdf(
+        &mixed,
+        Dictionary::new(),
+        vec![
+            media_box(0, 0, 419, 595),
+            rotated,
+            cropped,
+            // No box at all: A4 fallback must match render's fallback.
+            Dictionary::new(),
+        ],
+    );
+
+    for input in [&mixed, &fixture("11-pages.pdf")] {
+        let pages = page_dimensions(input).unwrap();
+        for dpi in [72.0f32, 144.0] {
+            let out = tempdir().unwrap();
+            let pattern = out.path().join("page-%d.png");
+            render_pages(
+                input,
+                pattern.to_str().unwrap(),
+                &RenderOptions { dpi, pages: None },
+            )
+            .unwrap();
+
+            let width = pages.len().to_string().len();
+            for (index, page) in pages.iter().enumerate() {
+                let path =
+                    out.path()
+                        .join(format!("page-{:0width$}.png", index + 1, width = width));
+                let (pixel_width, pixel_height) = png_dimensions(&path);
+                let scale = dpi / 72.0;
+                assert_eq!(
+                    (pixel_width, pixel_height),
+                    (
+                        ((page.width * scale) as f64).floor() as u32,
+                        ((page.height * scale) as f64).floor() as u32,
+                    ),
+                    "page {} of {} at {dpi} dpi",
+                    index + 1,
+                    input.display(),
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a native `pdq dimensions` command (and `pdq::page_dimensions` /
`page_dimensions_with_password` library API) that reports every page's size in
PDF points and its rotation straight from the page tree — no rasterization:

```
$ pdq dimensions [--password PW] input.pdf
{"pages":48,"page_sizes":[{"width":419,"height":595,"rotation":0},...,{"width":340,"height":680,"rotation":0}]}
```

Mixed-size documents report each page's true size, so a viewer can lay out
scrollbar height, virtualized positions, and placeholder boxes before fetching
any page image.

Closes #33

## How it works

- Rides on the same lazy, mmap-backed reader as `page-count`: the page list
  comes from the shared page-tree walk (it can never disagree with the pages
  `split`/`render` resolve), `--password` and transparent owner-password
  decryption work as elsewhere, and damaged xrefs get the usual repair retry.
- `MediaBox`/`CropBox`/`Rotate` are resolved through page-tree inheritance by
  walking `/Parent` chains with a per-node cache, tolerating indirect
  references at both the array and coordinate level.
- The geometry math replicates hayro's `Page::render_dimensions` exactly —
  effective box = CropBox∩MediaBox (CropBox defaults to MediaBox), missing
  MediaBox → A4, nearly-zero box → A4, per-dimension `max(1.0)`, the same
  f64→f32 cast points, `rem_euclid(360)` rotation normalization with 90/270
  swapping width/height — so `floor(width × dpi/72)`, computed in f32 like hayro computes it,
  equals the pixel size `pdq render` produces at that dpi. The precision
  matters: in f64 the formula predicts 1px too many on some DPI/page-size
  combinations (a Letter page at 150 dpi renders 1275×1649, not the 1275×1650
  doubles suggest), so the README documents the exact single-precision recipe
  for viewer authors (`Math.fround` in JS). A parity test asserts prediction ==
  rendered PNG size at 72, 96, 144, 150, 200, and 300 dpi, pinning the 150-dpi
  Letter case where f32 and f64 disagree.

## Edge cases

- Per-page damage degrades instead of failing the document: a missing or
  malformed box falls back to the inherited value, then A4; a malformed
  `/Rotate` falls back to 0.
- A box array with a non-numeric element is rejected whole (matching hayro's
  stop-at-first-non-numeric parsing) rather than shifting later coordinates
  into the wrong slots.
- Coordinates that overflow f32 to infinity fall back to A4: `render` refuses
  such pages ("too large to render"), and bare `inf` is not valid JSON.
- `rotation` is included per entry (the issue title asks for size + rotation),
  normalized to 0/90/180/270.

The command works without the `render` feature — it is a pure metadata walk.
