### PR TITLE
feat(copy): preserve annotations, /Info and XMP across split and merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,12 @@ digitally signed Brazilian court documents), the trailer `/Info` dictionary
 Annotation references back into document structure (`/Dest` arrays to pages
 outside the output, DocMDP `/Data` backreferences to the catalog) are
 replaced with `null` so they never pull unrelated pages — or the whole
-source document — into a page-subset output. Note that an embedded digital
+source document — into a page-subset output. Sanitization is single-pass, so
+within a multi-page output a GoTo link to a page copied *later* in that same
+output is also nulled (page content is never affected, only the link's
+destination). AcroForm field nodes reached through a widget's `/Parent` keep
+their field value (`/V` — the signature dictionary) but drop `/Kids`, which
+would otherwise drag the field's sibling widgets from other pages along. Note that an embedded digital
 signature survives as data but cannot stay *valid* on a page subset: its
 `/ByteRange` covers the original file's bytes, which any rewrite changes.
 `merge` follows the same rules, taking `/Info` and XMP from its first input.

--- a/README.md
+++ b/README.md
@@ -114,22 +114,14 @@ Outputs carry only the resources their pages actually use: unused fonts,
 images, and form XObjects shared across the source document are pruned so a
 3-page extract of a 200 MB file is small, not 200 MB.
 
-Outputs also keep what identifies the document: page annotations (link
-targets, form widgets, signature appearances — the visible gov.br stamp on
-digitally signed Brazilian court documents), the trailer `/Info` dictionary
-(author, producer, dates), and the catalog's XMP `/Metadata` stream.
-Annotation references back into document structure (`/Dest` arrays to pages
-outside the output, DocMDP `/Data` backreferences to the catalog) are
-replaced with `null` so they never pull unrelated pages — or the whole
-source document — into a page-subset output. Sanitization is single-pass, so
-within a multi-page output a GoTo link to a page copied *later* in that same
-output is also nulled (page content is never affected, only the link's
-destination). AcroForm field nodes reached through a widget's `/Parent` keep
-their field value (`/V` — the signature dictionary) but drop `/Kids`, which
-would otherwise drag the field's sibling widgets from other pages along. Note that an embedded digital
-signature survives as data but cannot stay *valid* on a page subset: its
-`/ByteRange` covers the original file's bytes, which any rewrite changes.
-`merge` follows the same rules, taking `/Info` and XMP from its first input.
+Outputs also keep page annotations (links, form widgets, signature
+appearances), the trailer `/Info` dictionary, and the catalog's XMP
+`/Metadata` stream. Annotation references into document structure, such as a
+`/Dest` pointing at a page outside the output, are nulled so they never pull
+unrelated pages into a subset. An embedded digital signature survives as
+data but cannot stay valid on a subset: its `/ByteRange` covers the original
+file's bytes. `merge` follows the same rules, taking `/Info` and XMP from
+its first input.
 
 A single `--out 1-z` output is a whole-document rewrite (normalize structure,
 drop unreferenced objects, decrypt): pdq streams objects from the

--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ Outputs carry only the resources their pages actually use: unused fonts,
 images, and form XObjects shared across the source document are pruned so a
 3-page extract of a 200 MB file is small, not 200 MB.
 
+Outputs also keep what identifies the document: page annotations (link
+targets, form widgets, signature appearances — the visible gov.br stamp on
+digitally signed Brazilian court documents), the trailer `/Info` dictionary
+(author, producer, dates), and the catalog's XMP `/Metadata` stream.
+Annotation references back into document structure (`/Dest` arrays to pages
+outside the output, DocMDP `/Data` backreferences to the catalog) are
+replaced with `null` so they never pull unrelated pages — or the whole
+source document — into a page-subset output. Note that an embedded digital
+signature survives as data but cannot stay *valid* on a page subset: its
+`/ByteRange` covers the original file's bytes, which any rewrite changes.
+`merge` follows the same rules, taking `/Info` and XMP from its first input.
+
 A single `--out 1-z` output is a whole-document rewrite (normalize structure,
 drop unreferenced objects, decrypt): pdq streams objects from the
 memory-mapped input straight to disk, so peak memory stays a few tens of MB

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -16,6 +16,14 @@ const RESOURCE_PRUNE_MIN_NAMES: usize = 6;
 
 pub(crate) trait ObjectSource {
     fn get_object_value(&self, id: ObjectId) -> std::result::Result<Cow<'_, Object>, lopdf::Error>;
+
+    /// The source trailer's value for `key` (`/Info`, `/Root`), when the
+    /// source exposes a trailer. Used to carry document-level metadata into
+    /// outputs; sources that cannot provide one (test doubles) keep the
+    /// default.
+    fn trailer_value(&self, _key: &[u8]) -> Option<Object> {
+        None
+    }
 }
 
 /// Distilled inheritable page attributes per page-tree node. `Arc` (not `Rc`)
@@ -25,6 +33,10 @@ pub(crate) type InheritedAttrsCache = BTreeMap<ObjectId, Arc<InheritedPageAttrs>
 impl ObjectSource for Document {
     fn get_object_value(&self, id: ObjectId) -> std::result::Result<Cow<'_, Object>, lopdf::Error> {
         Ok(Cow::Borrowed(self.get_object(id)?))
+    }
+
+    fn trailer_value(&self, key: &[u8]) -> Option<Object> {
+        self.trailer.get(key).ok().cloned()
     }
 }
 
@@ -37,7 +49,13 @@ pub struct CopyOptions {
 impl Default for CopyOptions {
     fn default() -> Self {
         Self {
-            copy_annotations: false,
+            // Annotations carry user-visible content — link targets, form
+            // widgets, and signature appearances (the gov.br stamp on Brazilian
+            // court documents) — so dropping them loses real page content.
+            // References back into document structure are sanitized during the
+            // copy (see `copy_sanitized_value`), which is what made copying
+            // them safe to enable.
+            copy_annotations: true,
             prune_resources: true,
         }
     }
@@ -52,6 +70,7 @@ pub struct CopyContext {
     selected_pages: BTreeSet<ObjectId>,
     options: CopyOptions,
     prune_nested_resources: bool,
+    sanitize_structure_refs: bool,
 }
 
 impl CopyContext {
@@ -88,6 +107,7 @@ impl CopyContext {
             selected_pages: BTreeSet::new(),
             options,
             prune_nested_resources: false,
+            sanitize_structure_refs: false,
         }
     }
 
@@ -237,7 +257,14 @@ impl CopyContext {
             if key.as_slice() == b"Parent" {
                 continue;
             }
-            if key.as_slice() == b"Annots" && !self.options.copy_annotations {
+            if key.as_slice() == b"Annots" {
+                if !self.options.copy_annotations {
+                    continue;
+                }
+                copied.set(
+                    key.clone(),
+                    self.copy_sanitized_value(source, target, value, depth + 1)?,
+                );
                 continue;
             }
             if key.as_slice() == b"Resources" {
@@ -362,12 +389,17 @@ impl CopyContext {
     ) -> Result<Object> {
         check_copy_depth(depth)?;
         match value {
-            Object::Reference(id) => Ok(Object::Reference(self.copy_object_at_depth(
-                source,
-                target,
-                *id,
-                depth + 1,
-            )?)),
+            Object::Reference(id) => {
+                if self.sanitize_structure_refs && self.is_document_structure_ref(source, *id) {
+                    return Ok(Object::Null);
+                }
+                Ok(Object::Reference(self.copy_object_at_depth(
+                    source,
+                    target,
+                    *id,
+                    depth + 1,
+                )?))
+            }
             Object::Array(items) => {
                 let mut copied = Vec::with_capacity(items.len());
                 for item in items {
@@ -398,12 +430,17 @@ impl CopyContext {
     ) -> Result<Object> {
         check_copy_depth(depth)?;
         match value {
-            Object::Reference(id) => Ok(Object::Reference(self.copy_object_at_depth(
-                source,
-                target,
-                id,
-                depth + 1,
-            )?)),
+            Object::Reference(id) => {
+                if self.sanitize_structure_refs && self.is_document_structure_ref(source, id) {
+                    return Ok(Object::Null);
+                }
+                Ok(Object::Reference(self.copy_object_at_depth(
+                    source,
+                    target,
+                    id,
+                    depth + 1,
+                )?))
+            }
             Object::Array(items) => {
                 let mut copied = Vec::with_capacity(items.len());
                 for item in items {
@@ -529,6 +566,95 @@ impl CopyContext {
         let result = self.copy_value(source, target, value, depth);
         self.prune_nested_resources = previous;
         result
+    }
+
+    /// Copy `value` with document-structure references sanitized: any
+    /// reference that resolves to the catalog, a page-tree node, the structure
+    /// tree, or a page that is not part of this copy is replaced with null
+    /// instead of being followed. Annotations (and document metadata) may
+    /// legally point back into the document — `/Dest` arrays, popup parents,
+    /// DocMDP `/Data` — and following such a reference from a page-subset copy
+    /// would pull unrelated pages, or the entire source document, into the
+    /// output.
+    fn copy_sanitized_value(
+        &mut self,
+        source: &impl ObjectSource,
+        target: &mut Document,
+        value: &Object,
+        depth: usize,
+    ) -> Result<Object> {
+        let previous = self.sanitize_structure_refs;
+        self.sanitize_structure_refs = true;
+        let result = self.copy_value(source, target, value, depth);
+        self.sanitize_structure_refs = previous;
+        result
+    }
+
+    /// True when `id` resolves to document structure that a sanitized copy
+    /// must not follow. Pages already visited by this copy (the annotation's
+    /// own page via `/P`, or a sibling page of the same output) stay
+    /// referenceable through the object map; a page copied later in the same
+    /// output is conservatively nulled — that only affects intra-output
+    /// `/Dest` links, never page content.
+    fn is_document_structure_ref(&self, source: &impl ObjectSource, id: ObjectId) -> bool {
+        if self.object_map.contains_key(&id) {
+            return false;
+        }
+        let Ok(object) = source.get_object_value(id) else {
+            return false;
+        };
+        let Ok(dict) = object.as_dict() else {
+            return false;
+        };
+        dict.has_type(b"Page")
+            || dict.has_type(b"Pages")
+            || dict.has_type(b"Catalog")
+            || dict.has_type(b"StructTreeRoot")
+    }
+
+    /// Copy the source's document-level metadata objects — the trailer `/Info`
+    /// dictionary and the catalog's XMP `/Metadata` stream — into `target`,
+    /// returning reference values for [`attach_document_metadata`] to hang on
+    /// the output once `finish_pages` has built its trailer and catalog.
+    ///
+    /// Metadata is best-effort: a damaged `/Info` or `/Metadata` object must
+    /// never fail the page operation itself, so copy errors leave the
+    /// corresponding slot empty (any objects copied before the error stay in
+    /// `target` unreferenced, which is harmless).
+    pub(crate) fn copy_document_metadata_objects(
+        &mut self,
+        source: &impl ObjectSource,
+        target: &mut Document,
+    ) -> CopiedDocumentMetadata {
+        let mut metadata = CopiedDocumentMetadata::default();
+        if let Some(info) = source.trailer_value(b"Info") {
+            metadata.info = self
+                .copy_sanitized_value(source, target, &info, 0)
+                .ok()
+                .and_then(|copied| match copied {
+                    reference @ Object::Reference(_) => Some(reference),
+                    // A direct trailer /Info dictionary is materialized as an
+                    // indirect object, which is what the spec requires of the
+                    // output trailer.
+                    Object::Dictionary(dictionary) => {
+                        Some(Object::Reference(target.add_object(dictionary)))
+                    }
+                    _ => None,
+                });
+        }
+        if let Some(Object::Reference(root_id)) = source.trailer_value(b"Root") {
+            let xmp = source
+                .get_object_value(root_id)
+                .ok()
+                .and_then(|root| root.as_dict().ok()?.get(b"Metadata").ok().cloned());
+            if let Some(value) = xmp {
+                metadata.xmp = self
+                    .copy_sanitized_value(source, target, &value, 0)
+                    .ok()
+                    .filter(|copied| matches!(copied, Object::Reference(_)));
+            }
+        }
+        metadata
     }
 
     fn resolve_dictionary<'a>(
@@ -736,22 +862,50 @@ fn is_form_xobject(dict: &Dictionary) -> bool {
     dict.get(b"Subtype").and_then(Object::as_name).ok() == Some(b"Form")
 }
 
-pub(crate) fn copy_pages_with_options(
+/// Document-level metadata copied into a target by
+/// [`CopyContext::copy_document_metadata_objects`], as reference values ready
+/// to be attached to the output trailer and catalog.
+#[derive(Debug, Default)]
+pub(crate) struct CopiedDocumentMetadata {
+    pub(crate) info: Option<Object>,
+    pub(crate) xmp: Option<Object>,
+}
+
+/// Attach previously copied document metadata to `target`: `/Info` on the
+/// trailer and the XMP `/Metadata` stream on the catalog. Must run after
+/// `finish_pages` has set the trailer's `/Root`.
+pub(crate) fn attach_document_metadata(
+    target: &mut Document,
+    metadata: &CopiedDocumentMetadata,
+) -> Result<()> {
+    if let Some(info) = &metadata.info {
+        target.trailer.set("Info", info.clone());
+    }
+    if let Some(xmp) = &metadata.xmp {
+        let catalog_id = target
+            .trailer
+            .get(b"Root")
+            .and_then(Object::as_reference)
+            .map_err(PdfOpsError::Pdf)?;
+        let catalog = target
+            .get_object_mut(catalog_id)?
+            .as_dict_mut()
+            .map_err(|_| PdfOpsError::InvalidStructure("catalog is not a dictionary".into()))?;
+        catalog.set("Metadata", xmp.clone());
+    }
+    Ok(())
+}
+
+pub(crate) fn copy_pages_with_context(
     source: &impl ObjectSource,
     target: &mut Document,
     page_ids: &[ObjectId],
-    options: CopyOptions,
+    context: &mut CopyContext,
 ) -> Result<Vec<ObjectId>> {
     let mut copied_pages = Vec::with_capacity(page_ids.len());
-    // Annotation preservation is intentionally deferred because annotation
-    // dictionaries often contain page/document backreferences that need
-    // careful remapping.
-    let mut context = CopyContext::new(options);
-
     for page_id in page_ids {
         copied_pages.push(context.copy_page(source, target, *page_id)?);
     }
-
     Ok(copied_pages)
 }
 

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -18,9 +18,7 @@ pub(crate) trait ObjectSource {
     fn get_object_value(&self, id: ObjectId) -> std::result::Result<Cow<'_, Object>, lopdf::Error>;
 
     /// The source trailer's value for `key` (`/Info`, `/Root`), when the
-    /// source exposes a trailer. Used to carry document-level metadata into
-    /// outputs; sources that cannot provide one (test doubles) keep the
-    /// default.
+    /// source exposes a trailer.
     fn trailer_value(&self, _key: &[u8]) -> Option<Object> {
         None
     }
@@ -49,12 +47,9 @@ pub struct CopyOptions {
 impl Default for CopyOptions {
     fn default() -> Self {
         Self {
-            // Annotations carry user-visible content — link targets, form
-            // widgets, and signature appearances (the gov.br stamp on Brazilian
-            // court documents) — so dropping them loses real page content.
-            // References back into document structure are sanitized during the
-            // copy (see `copy_sanitized_value`), which is what made copying
-            // them safe to enable.
+            // Annotations are user-visible content (links, form widgets,
+            // signature appearances); references back into document structure
+            // are sanitized during the copy (see `copy_sanitized_value`).
             copy_annotations: true,
             prune_resources: true,
         }
@@ -452,8 +447,7 @@ impl CopyContext {
                 let mut copied = lopdf::Dictionary::new();
                 for (key, value) in dict {
                     // Same /Kids drop as `copy_dictionary` (see the comment
-                    // there): field nodes reached from a sanitized subtree
-                    // must not drag sibling widgets from other pages along.
+                    // there).
                     if self.sanitize_structure_refs && key.as_slice() == b"Kids" {
                         continue;
                     }
@@ -553,16 +547,11 @@ impl CopyContext {
         let mut copied = Dictionary::new();
         for (key, value) in dict.iter() {
             if self.sanitize_structure_refs && key.as_slice() == b"Kids" {
-                // Inside a sanitized (annotation/metadata) subtree the only
-                // dictionaries carrying /Kids are AcroForm field nodes reached
-                // through a widget's /Parent — field nodes have no /Type, so
-                // the structure guard cannot catch them. Their /Kids lists the
-                // field's widgets across the WHOLE document; copying it would
-                // drag sibling widgets (and their appearance streams) from
-                // other pages into a subset output. Dropping /Kids keeps the
-                // field itself — crucially its /V signature value — while the
-                // output's own widget is already reachable via the page's
-                // /Annots.
+                // In a sanitized subtree, /Kids appears on AcroForm field
+                // nodes (reached via a widget's /Parent) and lists the field's
+                // widgets across the whole document; copying it would drag
+                // sibling widgets from other pages into the output. Dropping
+                // it keeps the field and its /V value.
                 continue;
             }
             copied.set(
@@ -587,14 +576,12 @@ impl CopyContext {
         result
     }
 
-    /// Copy `value` with document-structure references sanitized: any
-    /// reference that resolves to the catalog, a page-tree node, the structure
-    /// tree, or a page that is not part of this copy is replaced with null
-    /// instead of being followed. Annotations (and document metadata) may
-    /// legally point back into the document — `/Dest` arrays, popup parents,
-    /// DocMDP `/Data` — and following such a reference from a page-subset copy
-    /// would pull unrelated pages, or the entire source document, into the
-    /// output.
+    /// Copy `value` with document-structure references sanitized: a reference
+    /// resolving to the catalog, a page-tree node, the structure tree, or a
+    /// page outside this copy is replaced with null instead of followed.
+    /// Annotations may legally point back into the document (`/Dest`, DocMDP
+    /// `/Data`), and following such a reference would pull unrelated pages
+    /// into the output.
     fn copy_sanitized_value(
         &mut self,
         source: &impl ObjectSource,
@@ -614,15 +601,10 @@ impl CopyContext {
         references_document_structure(source, &self.object_map, id)
     }
 
-    /// Copy the source's document-level metadata objects — the trailer `/Info`
-    /// dictionary and the catalog's XMP `/Metadata` stream — into `target`,
-    /// returning reference values for [`attach_document_metadata`] to hang on
-    /// the output once `finish_pages` has built its trailer and catalog.
-    ///
-    /// Metadata is best-effort: a damaged `/Info` or `/Metadata` object must
-    /// never fail the page operation itself, so copy errors leave the
-    /// corresponding slot empty (any objects copied before the error stay in
-    /// `target` unreferenced, which is harmless).
+    /// Copy the trailer `/Info` dictionary and the catalog's XMP `/Metadata`
+    /// stream into `target`, returning references for
+    /// [`attach_document_metadata`]. Best-effort: damaged metadata never fails
+    /// the page operation; copy errors leave the slot empty.
     pub(crate) fn copy_document_metadata_objects(
         &mut self,
         source: &impl ObjectSource,
@@ -635,9 +617,7 @@ impl CopyContext {
                 .ok()
                 .and_then(|copied| match copied {
                     reference @ Object::Reference(_) => Some(reference),
-                    // A direct trailer /Info dictionary is materialized as an
-                    // indirect object, which is what the spec requires of the
-                    // output trailer.
+                    // The spec requires the trailer /Info to be indirect.
                     Object::Dictionary(dictionary) => {
                         Some(Object::Reference(target.add_object(dictionary)))
                     }
@@ -865,12 +845,10 @@ fn is_form_xobject(dict: &Dictionary) -> bool {
 }
 
 /// True when `id` resolves to document structure that a sanitized copy must
-/// not follow. Pages already visited by the copy (the annotation's own page
-/// via `/P`, or a sibling page of the same output) stay referenceable through
+/// not follow. Pages already visited by the copy stay referenceable through
 /// `object_map`; a page copied later in the same output is conservatively
-/// nulled — that only affects intra-output `/Dest` links, never page content.
-/// Shared by `CopyContext` and `StreamingCopyContext` so the structure-type
-/// list can never drift between the two.
+/// nulled, which only affects intra-output `/Dest` links, never page content.
+/// Shared by `CopyContext` and `StreamingCopyContext`.
 pub(crate) fn references_document_structure(
     source: &impl ObjectSource,
     object_map: &BTreeMap<ObjectId, ObjectId>,
@@ -891,18 +869,16 @@ pub(crate) fn references_document_structure(
         || dict.has_type(b"StructTreeRoot")
 }
 
-/// Document-level metadata copied into a target by
-/// [`CopyContext::copy_document_metadata_objects`], as reference values ready
-/// to be attached to the output trailer and catalog.
+/// References to copied `/Info` and XMP `/Metadata` objects, ready to be
+/// attached to the output trailer and catalog.
 #[derive(Debug, Default)]
 pub(crate) struct CopiedDocumentMetadata {
     pub(crate) info: Option<Object>,
     pub(crate) xmp: Option<Object>,
 }
 
-/// Attach previously copied document metadata to `target`: `/Info` on the
-/// trailer and the XMP `/Metadata` stream on the catalog. Must run after
-/// `finish_pages` has set the trailer's `/Root`.
+/// Attach copied metadata to `target`: `/Info` on the trailer, XMP
+/// `/Metadata` on the catalog. Must run after `finish_pages` has set `/Root`.
 pub(crate) fn attach_document_metadata(
     target: &mut Document,
     metadata: &CopiedDocumentMetadata,

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -451,6 +451,12 @@ impl CopyContext {
             Object::Dictionary(dict) => {
                 let mut copied = lopdf::Dictionary::new();
                 for (key, value) in dict {
+                    // Same /Kids drop as `copy_dictionary` (see the comment
+                    // there): field nodes reached from a sanitized subtree
+                    // must not drag sibling widgets from other pages along.
+                    if self.sanitize_structure_refs && key.as_slice() == b"Kids" {
+                        continue;
+                    }
                     copied.set(
                         key,
                         self.copy_owned_value(source, target, value, depth + 1)?,
@@ -546,6 +552,19 @@ impl CopyContext {
         check_copy_depth(depth)?;
         let mut copied = Dictionary::new();
         for (key, value) in dict.iter() {
+            if self.sanitize_structure_refs && key.as_slice() == b"Kids" {
+                // Inside a sanitized (annotation/metadata) subtree the only
+                // dictionaries carrying /Kids are AcroForm field nodes reached
+                // through a widget's /Parent — field nodes have no /Type, so
+                // the structure guard cannot catch them. Their /Kids lists the
+                // field's widgets across the WHOLE document; copying it would
+                // drag sibling widgets (and their appearance streams) from
+                // other pages into a subset output. Dropping /Kids keeps the
+                // field itself — crucially its /V signature value — while the
+                // output's own widget is already reachable via the page's
+                // /Annots.
+                continue;
+            }
             copied.set(
                 key.clone(),
                 self.copy_value(source, target, value, depth + 1)?,
@@ -590,26 +609,9 @@ impl CopyContext {
         result
     }
 
-    /// True when `id` resolves to document structure that a sanitized copy
-    /// must not follow. Pages already visited by this copy (the annotation's
-    /// own page via `/P`, or a sibling page of the same output) stay
-    /// referenceable through the object map; a page copied later in the same
-    /// output is conservatively nulled — that only affects intra-output
-    /// `/Dest` links, never page content.
+    /// See [`references_document_structure`].
     fn is_document_structure_ref(&self, source: &impl ObjectSource, id: ObjectId) -> bool {
-        if self.object_map.contains_key(&id) {
-            return false;
-        }
-        let Ok(object) = source.get_object_value(id) else {
-            return false;
-        };
-        let Ok(dict) = object.as_dict() else {
-            return false;
-        };
-        dict.has_type(b"Page")
-            || dict.has_type(b"Pages")
-            || dict.has_type(b"Catalog")
-            || dict.has_type(b"StructTreeRoot")
+        references_document_structure(source, &self.object_map, id)
     }
 
     /// Copy the source's document-level metadata objects — the trailer `/Info`
@@ -860,6 +862,33 @@ fn restore_object_mapping(
 
 fn is_form_xobject(dict: &Dictionary) -> bool {
     dict.get(b"Subtype").and_then(Object::as_name).ok() == Some(b"Form")
+}
+
+/// True when `id` resolves to document structure that a sanitized copy must
+/// not follow. Pages already visited by the copy (the annotation's own page
+/// via `/P`, or a sibling page of the same output) stay referenceable through
+/// `object_map`; a page copied later in the same output is conservatively
+/// nulled — that only affects intra-output `/Dest` links, never page content.
+/// Shared by `CopyContext` and `StreamingCopyContext` so the structure-type
+/// list can never drift between the two.
+pub(crate) fn references_document_structure(
+    source: &impl ObjectSource,
+    object_map: &BTreeMap<ObjectId, ObjectId>,
+    id: ObjectId,
+) -> bool {
+    if object_map.contains_key(&id) {
+        return false;
+    }
+    let Ok(object) = source.get_object_value(id) else {
+        return false;
+    };
+    let Ok(dict) = object.as_dict() else {
+        return false;
+    };
+    dict.has_type(b"Page")
+        || dict.has_type(b"Pages")
+        || dict.has_type(b"Catalog")
+        || dict.has_type(b"StructTreeRoot")
 }
 
 /// Document-level metadata copied into a target by

--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -175,6 +175,13 @@ impl ObjectSource for PdfSource<'_> {
             Self::Eager(document) => document.get_object_value(id),
         }
     }
+
+    fn trailer_value(&self, key: &[u8]) -> Option<Object> {
+        match self {
+            Self::Lazy(lazy) => lazy.reader.document.trailer.get(key).ok().cloned(),
+            Self::Eager(document) => document.trailer.get(key).ok().cloned(),
+        }
+    }
 }
 
 pub(crate) struct LazyPdf<'a> {

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -77,8 +77,7 @@ pub fn merge_with_options(
     'attempt: loop {
         let mut target = empty_document();
         let mut merged_pages = Vec::new();
-        // Document metadata (/Info, XMP) follows qpdf's convention: the FIRST
-        // input is the primary document and donates its metadata.
+        // qpdf convention: the first input donates /Info and XMP.
         let mut document_metadata = CopiedDocumentMetadata::default();
 
         for (index, input) in inputs.iter().enumerate() {
@@ -220,8 +219,7 @@ fn append_whole_source(
             },
         );
         let pages = context.copy_pages(source, page_ids)?;
-        // Same convention as the ranged merge: only the first input donates
-        // its /Info and XMP metadata to the output.
+        // Same convention as the ranged merge: only the first input donates.
         let metadata = donates_metadata.then(|| context.copy_document_metadata_objects(source));
         (pages, metadata)
     };

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -6,7 +6,10 @@ use std::{
 };
 
 use crate::{
-    copy::{copy_pages_with_options, CopyOptions},
+    copy::{
+        attach_document_metadata, copy_pages_with_context, CopiedDocumentMetadata, CopyContext,
+        CopyOptions,
+    },
     lazy::PdfSource,
     load::map_file,
     range::{PageRangeError, PageRangeGroup},
@@ -74,26 +77,31 @@ pub fn merge_with_options(
     'attempt: loop {
         let mut target = empty_document();
         let mut merged_pages = Vec::new();
+        // Document metadata (/Info, XMP) follows qpdf's convention: the FIRST
+        // input is the primary document and donates its metadata.
+        let mut document_metadata = CopiedDocumentMetadata::default();
 
         for (index, input) in inputs.iter().enumerate() {
             let mmap = map_file(&input.path)?;
             let source =
                 open_merge_source(&mmap, &input.path, password, force_repair.contains(&index))?;
+            let mut context = CopyContext::new(CopyOptions {
+                prune_resources: !input.ranges.is_empty(),
+                ..CopyOptions::default()
+            });
             let copied = (|| {
                 let pages = source.page_ids()?;
                 let page_ids = resolve_merge_page_ids(&pages, input)?;
-                copy_pages_with_options(
-                    &source,
-                    &mut target,
-                    &page_ids,
-                    CopyOptions {
-                        prune_resources: !input.ranges.is_empty(),
-                        ..CopyOptions::default()
-                    },
-                )
+                copy_pages_with_context(&source, &mut target, &page_ids, &mut context)
             })();
             match copied {
-                Ok(pages) => merged_pages.extend(pages),
+                Ok(pages) => {
+                    if index == 0 {
+                        document_metadata =
+                            context.copy_document_metadata_objects(&source, &mut target);
+                    }
+                    merged_pages.extend(pages);
+                }
                 Err(err) if is_offset_damage(&err) && !source.repaired() => {
                     force_repair.insert(index);
                     continue 'attempt;
@@ -103,6 +111,7 @@ pub fn merge_with_options(
         }
 
         finish_pages(&mut target, &merged_pages)?;
+        attach_document_metadata(&mut target, &document_metadata)?;
         target.save(output)?;
         return Ok(());
     }
@@ -151,7 +160,7 @@ pub(crate) fn merge_whole_inputs_streaming(
                     if page_ids.is_empty() {
                         return Err(PdfOpsError::Range(PageRangeError::NoPages));
                     }
-                    append_whole_source(writer, &source, &page_ids)
+                    append_whole_source(writer, &source, &page_ids, index == 0)
                 })();
                 if let Err(err) = appended {
                     if !source.repaired() {
@@ -200,8 +209,9 @@ fn append_whole_source(
     writer: &mut StreamingPdfWriter,
     source: &PdfSource<'_>,
     page_ids: &[lopdf::ObjectId],
+    donates_metadata: bool,
 ) -> Result<()> {
-    let copied_pages = {
+    let (copied_pages, metadata) = {
         let mut context = StreamingCopyContext::new(
             writer,
             CopyOptions {
@@ -209,9 +219,16 @@ fn append_whole_source(
                 ..CopyOptions::default()
             },
         );
-        context.copy_pages(source, page_ids)?
+        let pages = context.copy_pages(source, page_ids)?;
+        // Same convention as the ranged merge: only the first input donates
+        // its /Info and XMP metadata to the output.
+        let metadata = donates_metadata.then(|| context.copy_document_metadata_objects(source));
+        (pages, metadata)
     };
     writer.extend_pages(copied_pages);
+    if let Some(metadata) = metadata {
+        writer.set_document_metadata(metadata);
+    }
     Ok(())
 }
 
@@ -256,7 +273,7 @@ fn copy_whole_input(input: &MergeInput, output: &Path, password: Option<&str>) -
         }
         if source.was_encrypted() || source.repaired() {
             return write_streaming_output(output, |writer| {
-                append_whole_source(writer, source, &page_ids)
+                append_whole_source(writer, source, &page_ids, true)
             });
         }
         fs::copy(&input.path, output)?;

--- a/src/split.rs
+++ b/src/split.rs
@@ -7,7 +7,10 @@ use lopdf::{dictionary, Document, Object};
 use rayon::prelude::*;
 
 use crate::{
-    copy::{copy_pages_with_options, resolve_page_ids, CopyOptions, ObjectSource},
+    copy::{
+        attach_document_metadata, copy_pages_with_context, resolve_page_ids, CopyContext,
+        CopyOptions, ObjectSource,
+    },
     load::{load_document, map_file},
     merge::merge_whole_inputs_streaming,
     range::{PageRangeError, PageRangeGroup},
@@ -321,8 +324,12 @@ fn run_split_outputs(
             prune_resources: output.prune_resources,
             ..CopyOptions::default()
         };
-        let copied_pages = copy_pages_with_options(source, &mut target, &output.page_ids, options)?;
+        let mut context = CopyContext::new(options);
+        let copied_pages =
+            copy_pages_with_context(source, &mut target, &output.page_ids, &mut context)?;
+        let metadata = context.copy_document_metadata_objects(source, &mut target);
         finish_pages(&mut target, &copied_pages)?;
+        attach_document_metadata(&mut target, &metadata)?;
         target.save(&output.path)?;
         Ok(())
     };

--- a/src/split_template.rs
+++ b/src/split_template.rs
@@ -147,10 +147,8 @@ impl SinglePageTemplate {
             self.inherited_attrs.clone(),
         );
         let new_page_id = context.copy_page(source, &mut scratch, page_id)?;
-        // Document metadata is copied per output rather than into the shared
-        // prefix: /Info and XMP are not reachable from any page, so they never
-        // land in the probed shared closure. Small objects; correctness over
-        // dedup.
+        // Metadata is copied per output: /Info and XMP are not reachable from
+        // any page, so they never land in the probed shared prefix.
         let metadata = context.copy_document_metadata_objects(source, &mut scratch);
         finish_pages(&mut scratch, &[new_page_id])?;
         attach_document_metadata(&mut scratch, &metadata)?;

--- a/src/split_template.rs
+++ b/src/split_template.rs
@@ -28,7 +28,7 @@ use std::{
 use lopdf::{dictionary, Object, ObjectId};
 
 use crate::{
-    copy::{CopyContext, CopyOptions, InheritedAttrsCache, ObjectSource},
+    copy::{attach_document_metadata, CopyContext, CopyOptions, InheritedAttrsCache, ObjectSource},
     split::{empty_document, finish_pages},
     write::{write_dictionary, write_object},
     PdfOpsError, Result,
@@ -147,12 +147,19 @@ impl SinglePageTemplate {
             self.inherited_attrs.clone(),
         );
         let new_page_id = context.copy_page(source, &mut scratch, page_id)?;
+        // Document metadata is copied per output rather than into the shared
+        // prefix: /Info and XMP are not reachable from any page, so they never
+        // land in the probed shared closure. Small objects; correctness over
+        // dedup.
+        let metadata = context.copy_document_metadata_objects(source, &mut scratch);
         finish_pages(&mut scratch, &[new_page_id])?;
+        attach_document_metadata(&mut scratch, &metadata)?;
         let root = scratch
             .trailer
             .get(b"Root")
             .map_err(PdfOpsError::Pdf)?
             .clone();
+        let info = scratch.trailer.get(b"Info").ok().cloned();
 
         buffer.clear();
         buffer.extend_from_slice(&self.prefix);
@@ -181,10 +188,13 @@ impl SinglePageTemplate {
         buffer.extend_from_slice(&self.xref_prefix);
         buffer.extend_from_slice(&xref_tail);
         buffer.extend_from_slice(b"trailer\n");
-        let trailer = dictionary! {
+        let mut trailer = dictionary! {
             "Size" => (max_id + 1) as i64,
             "Root" => root,
         };
+        if let Some(info) = info {
+            trailer.set("Info", info);
+        }
         write_dictionary(buffer, &trailer)?;
         write!(buffer, "\nstartxref\n{xref_start}\n%%EOF")?;
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -146,12 +146,9 @@ impl<'a> StreamingCopyContext<'a> {
         }
     }
 
-    /// Copy the source's document-level metadata objects — the trailer `/Info`
-    /// dictionary and the catalog's XMP `/Metadata` stream — through the
-    /// streaming writer. Mirrors `CopyContext::copy_document_metadata_objects`:
-    /// best-effort (metadata must never fail the merge) and sanitized (a
-    /// malformed metadata object must not smuggle the source page tree into
-    /// the output).
+    /// Streaming mirror of `CopyContext::copy_document_metadata_objects`:
+    /// copy the trailer `/Info` and catalog XMP `/Metadata` through the
+    /// streaming writer, best-effort and sanitized.
     pub(crate) fn copy_document_metadata_objects(
         &mut self,
         source: &impl ObjectSource,
@@ -377,9 +374,7 @@ impl<'a> StreamingCopyContext<'a> {
                 let mut copied = Dictionary::new();
                 for (key, value) in dict.iter() {
                     // Same /Kids drop as CopyContext::copy_dictionary (see the
-                    // comment there): AcroForm field nodes reached from a
-                    // sanitized subtree must not drag sibling widgets from
-                    // other pages along.
+                    // comment there).
                     if self.sanitize_structure_refs && key.as_slice() == b"Kids" {
                         continue;
                     }

--- a/src/write.rs
+++ b/src/write.rs
@@ -10,7 +10,7 @@ use std::{
 use lopdf::{dictionary, Dictionary, Object, ObjectId, StringFormat};
 
 use crate::{
-    copy::{CopyOptions, ObjectSource},
+    copy::{CopiedDocumentMetadata, CopyOptions, ObjectSource},
     PdfOpsError, Result,
 };
 
@@ -24,6 +24,7 @@ pub(crate) struct StreamingPdfWriter {
     pages_id: ObjectId,
     catalog_id: ObjectId,
     pages: Vec<ObjectId>,
+    document_metadata: CopiedDocumentMetadata,
 }
 
 impl StreamingPdfWriter {
@@ -39,6 +40,7 @@ impl StreamingPdfWriter {
             pages_id: (0, 0),
             catalog_id: (0, 0),
             pages: Vec::new(),
+            document_metadata: CopiedDocumentMetadata::default(),
         };
         writer.pages_id = writer.new_object_id();
         writer.catalog_id = writer.new_object_id();
@@ -56,6 +58,12 @@ impl StreamingPdfWriter {
 
     pub(crate) fn extend_pages(&mut self, pages: impl IntoIterator<Item = ObjectId>) {
         self.pages.extend(pages);
+    }
+
+    /// Record document metadata (already written as objects) to be attached
+    /// at `finish`: `/Info` on the trailer, XMP `/Metadata` on the catalog.
+    pub(crate) fn set_document_metadata(&mut self, metadata: CopiedDocumentMetadata) {
+        self.document_metadata = metadata;
     }
 
     pub(crate) fn write_object(&mut self, id: ObjectId, object: &Object) -> Result<()> {
@@ -83,10 +91,13 @@ impl StreamingPdfWriter {
         };
         self.write_object(self.pages_id, &Object::Dictionary(pages))?;
 
-        let catalog = dictionary! {
+        let mut catalog = dictionary! {
             "Type" => "Catalog",
             "Pages" => self.pages_id,
         };
+        if let Some(xmp) = &self.document_metadata.xmp {
+            catalog.set("Metadata", xmp.clone());
+        }
         self.write_object(self.catalog_id, &Object::Dictionary(catalog))?;
 
         let xref_start = self.output.bytes_written();
@@ -100,10 +111,13 @@ impl StreamingPdfWriter {
             writeln!(self.output, "{offset:010} 00000 n ")?;
         }
         self.output.write_all(b"trailer\n")?;
-        let trailer = dictionary! {
+        let mut trailer = dictionary! {
             "Size" => (self.max_id + 1) as i64,
             "Root" => self.catalog_id,
         };
+        if let Some(info) = &self.document_metadata.info {
+            trailer.set("Info", info.clone());
+        }
         write_dictionary(&mut self.output, &trailer)?;
         write!(self.output, "\nstartxref\n{xref_start}\n%%EOF")?;
         self.output.flush()?;
@@ -117,6 +131,7 @@ pub(crate) struct StreamingCopyContext<'a> {
     inherited_attrs_cache: BTreeMap<ObjectId, Rc<InheritedPageAttrs>>,
     selected_pages: BTreeSet<ObjectId>,
     options: CopyOptions,
+    sanitize_structure_refs: bool,
 }
 
 impl<'a> StreamingCopyContext<'a> {
@@ -127,7 +142,81 @@ impl<'a> StreamingCopyContext<'a> {
             inherited_attrs_cache: BTreeMap::new(),
             selected_pages: BTreeSet::new(),
             options,
+            sanitize_structure_refs: false,
         }
+    }
+
+    /// Copy the source's document-level metadata objects — the trailer `/Info`
+    /// dictionary and the catalog's XMP `/Metadata` stream — through the
+    /// streaming writer. Mirrors `CopyContext::copy_document_metadata_objects`:
+    /// best-effort (metadata must never fail the merge) and sanitized (a
+    /// malformed metadata object must not smuggle the source page tree into
+    /// the output).
+    pub(crate) fn copy_document_metadata_objects(
+        &mut self,
+        source: &impl ObjectSource,
+    ) -> CopiedDocumentMetadata {
+        let mut metadata = CopiedDocumentMetadata::default();
+        if let Some(info) = source.trailer_value(b"Info") {
+            metadata.info = self
+                .copy_sanitized_value(source, &info, 0)
+                .ok()
+                .and_then(|copied| match copied {
+                    reference @ Object::Reference(_) => Some(reference),
+                    Object::Dictionary(dictionary) => {
+                        let id = self.writer.new_object_id();
+                        self.writer
+                            .write_object(id, &Object::Dictionary(dictionary))
+                            .ok()?;
+                        Some(Object::Reference(id))
+                    }
+                    _ => None,
+                });
+        }
+        if let Some(Object::Reference(root_id)) = source.trailer_value(b"Root") {
+            let xmp = source
+                .get_object_value(root_id)
+                .ok()
+                .and_then(|root| root.as_dict().ok()?.get(b"Metadata").ok().cloned());
+            if let Some(value) = xmp {
+                metadata.xmp = self
+                    .copy_sanitized_value(source, &value, 0)
+                    .ok()
+                    .filter(|copied| matches!(copied, Object::Reference(_)));
+            }
+        }
+        metadata
+    }
+
+    /// See `CopyContext::copy_sanitized_value`.
+    fn copy_sanitized_value(
+        &mut self,
+        source: &impl ObjectSource,
+        value: &Object,
+        depth: usize,
+    ) -> Result<Object> {
+        let previous = self.sanitize_structure_refs;
+        self.sanitize_structure_refs = true;
+        let result = self.copy_value(source, value, depth);
+        self.sanitize_structure_refs = previous;
+        result
+    }
+
+    /// See `CopyContext::is_document_structure_ref`.
+    fn is_document_structure_ref(&self, source: &impl ObjectSource, id: ObjectId) -> bool {
+        if self.object_map.contains_key(&id) {
+            return false;
+        }
+        let Ok(object) = source.get_object_value(id) else {
+            return false;
+        };
+        let Ok(dict) = object.as_dict() else {
+            return false;
+        };
+        dict.has_type(b"Page")
+            || dict.has_type(b"Pages")
+            || dict.has_type(b"Catalog")
+            || dict.has_type(b"StructTreeRoot")
     }
 
     pub(crate) fn copy_pages(
@@ -245,7 +334,14 @@ impl<'a> StreamingCopyContext<'a> {
             if key.as_slice() == b"Parent" {
                 continue;
             }
-            if key.as_slice() == b"Annots" && !self.options.copy_annotations {
+            if key.as_slice() == b"Annots" {
+                if !self.options.copy_annotations {
+                    continue;
+                }
+                copied.set(
+                    key.clone(),
+                    self.copy_sanitized_value(source, value, depth + 1)?,
+                );
                 continue;
             }
             copied.set(key.clone(), self.copy_value(source, value, depth + 1)?);
@@ -272,11 +368,16 @@ impl<'a> StreamingCopyContext<'a> {
     ) -> Result<Object> {
         check_copy_depth(depth)?;
         match value {
-            Object::Reference(id) => Ok(Object::Reference(self.copy_object_at_depth(
-                source,
-                *id,
-                depth + 1,
-            )?)),
+            Object::Reference(id) => {
+                if self.sanitize_structure_refs && self.is_document_structure_ref(source, *id) {
+                    return Ok(Object::Null);
+                }
+                Ok(Object::Reference(self.copy_object_at_depth(
+                    source,
+                    *id,
+                    depth + 1,
+                )?))
+            }
             Object::Array(items) => {
                 let mut copied = Vec::with_capacity(items.len());
                 for item in items {
@@ -308,11 +409,16 @@ impl<'a> StreamingCopyContext<'a> {
     ) -> Result<Object> {
         check_copy_depth(depth)?;
         match value {
-            Object::Reference(id) => Ok(Object::Reference(self.copy_object_at_depth(
-                source,
-                id,
-                depth + 1,
-            )?)),
+            Object::Reference(id) => {
+                if self.sanitize_structure_refs && self.is_document_structure_ref(source, id) {
+                    return Ok(Object::Null);
+                }
+                Ok(Object::Reference(self.copy_object_at_depth(
+                    source,
+                    id,
+                    depth + 1,
+                )?))
+            }
             Object::Array(items) => {
                 let mut copied = Vec::with_capacity(items.len());
                 for item in items {

--- a/src/write.rs
+++ b/src/write.rs
@@ -10,7 +10,7 @@ use std::{
 use lopdf::{dictionary, Dictionary, Object, ObjectId, StringFormat};
 
 use crate::{
-    copy::{CopiedDocumentMetadata, CopyOptions, ObjectSource},
+    copy::{references_document_structure, CopiedDocumentMetadata, CopyOptions, ObjectSource},
     PdfOpsError, Result,
 };
 
@@ -202,21 +202,9 @@ impl<'a> StreamingCopyContext<'a> {
         result
     }
 
-    /// See `CopyContext::is_document_structure_ref`.
+    /// See [`references_document_structure`].
     fn is_document_structure_ref(&self, source: &impl ObjectSource, id: ObjectId) -> bool {
-        if self.object_map.contains_key(&id) {
-            return false;
-        }
-        let Ok(object) = source.get_object_value(id) else {
-            return false;
-        };
-        let Ok(dict) = object.as_dict() else {
-            return false;
-        };
-        dict.has_type(b"Page")
-            || dict.has_type(b"Pages")
-            || dict.has_type(b"Catalog")
-            || dict.has_type(b"StructTreeRoot")
+        references_document_structure(source, &self.object_map, id)
     }
 
     pub(crate) fn copy_pages(
@@ -388,6 +376,13 @@ impl<'a> StreamingCopyContext<'a> {
             Object::Dictionary(dict) => {
                 let mut copied = Dictionary::new();
                 for (key, value) in dict.iter() {
+                    // Same /Kids drop as CopyContext::copy_dictionary (see the
+                    // comment there): AcroForm field nodes reached from a
+                    // sanitized subtree must not drag sibling widgets from
+                    // other pages along.
+                    if self.sanitize_structure_refs && key.as_slice() == b"Kids" {
+                        continue;
+                    }
                     copied.set(key.clone(), self.copy_value(source, value, depth + 1)?);
                 }
                 Ok(Object::Dictionary(copied))
@@ -429,6 +424,9 @@ impl<'a> StreamingCopyContext<'a> {
             Object::Dictionary(dict) => {
                 let mut copied = Dictionary::new();
                 for (key, value) in dict {
+                    if self.sanitize_structure_refs && key.as_slice() == b"Kids" {
+                        continue;
+                    }
                     copied.set(key, self.copy_owned_value(source, value, depth + 1)?);
                 }
                 Ok(Object::Dictionary(copied))

--- a/tests/real_world.rs
+++ b/tests/real_world.rs
@@ -916,7 +916,7 @@ fn trf4_like_fixture_is_valid_and_counts_pages_in_flat_tree() {
 }
 
 #[test]
-fn pje_like_split_pages_keeps_drawn_filter_zoo_and_drops_annots() {
+fn pje_like_split_pages_keeps_drawn_filter_zoo_and_carries_annots() {
     let temp = tempdir().unwrap();
     let input = temp.path().join("pje-like.pdf");
     build_pje_like(&input, PJE_PAGES);
@@ -956,18 +956,34 @@ fn pje_like_split_pages_keeps_drawn_filter_zoo_and_drops_annots() {
         jbig2_page.display()
     );
 
-    // page 18 (index 17) had a link annotation; pdq drops annotations on
-    // split by default (CopyOptions::copy_annotations = false)
+    // page 18 (index 17) has a self-referential GoTo link (PJe "Fls." style):
+    // annotations are preserved on split, and the destination's page
+    // reference must be remapped to the output's own page object.
     let annotated_page = out_dir.join(split_page_name(18, PJE_PAGES));
     let document = Document::load(&annotated_page).unwrap();
-    let page = document
-        .get_object(single_page_id(&document))
-        .unwrap()
-        .as_dict()
-        .unwrap();
-    assert!(
-        page.get(b"Annots").is_err(),
-        "split outputs should not carry annotations by default"
+    let page_id = single_page_id(&document);
+    let page = document.get_object(page_id).unwrap().as_dict().unwrap();
+    let annots = page
+        .get(b"Annots")
+        .expect("split outputs must carry the page's annotations")
+        .as_array()
+        .expect("Annots should be an array");
+    assert_eq!(annots.len(), 1, "the link annotation should survive");
+    let annot = resolve_dict(&document, &annots[0]);
+    assert_eq!(
+        annot.get(b"Subtype").and_then(Object::as_name).unwrap(),
+        b"Link"
+    );
+    let action = annot.get(b"A").unwrap().as_dict().unwrap();
+    let dest = match action.get(b"D").unwrap() {
+        Object::Reference(id) => document.get_object(*id).unwrap().as_array().unwrap(),
+        Object::Array(items) => items,
+        other => panic!("unexpected /D destination: {other:?}"),
+    };
+    assert_eq!(
+        dest[0],
+        Object::Reference(page_id),
+        "self-referential GoTo destination must be remapped to the output page"
     );
 
     let qpdf = QpdfValidator::detect();

--- a/tests/split_merge.rs
+++ b/tests/split_merge.rs
@@ -1790,7 +1790,10 @@ fn resolve_to_dict<'a>(document: &'a Document, value: &Object) -> &'a Dictionary
 }
 
 fn author_of(document: &Document) -> String {
-    let info = document.trailer.get(b"Info").expect("output must carry /Info");
+    let info = document
+        .trailer
+        .get(b"Info")
+        .expect("output must carry /Info");
     let author = resolve_to_dict(document, info).get(b"Author").unwrap();
     String::from_utf8_lossy(author.as_str().unwrap()).into_owned()
 }
@@ -1859,7 +1862,12 @@ fn split_preserves_document_metadata_and_sanitized_annotations() {
     assert_eq!(sig_widget.get(b"P").unwrap(), &Object::Reference(pages[&1]));
     let sig_dict = resolve_to_dict(&document, sig_widget.get(b"V").unwrap());
     assert_eq!(
-        sig_dict.get(b"ByteRange").unwrap().as_array().unwrap().len(),
+        sig_dict
+            .get(b"ByteRange")
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .len(),
         4
     );
     let sig_ref = resolve_to_dict(

--- a/tests/split_merge.rs
+++ b/tests/split_merge.rs
@@ -1952,3 +1952,133 @@ fn merge_takes_document_metadata_from_first_input() {
     assert!(xmp_content_of(&document).starts_with(b"<?xpacket"));
     QpdfValidator::detect().validate(&ranged, 3);
 }
+
+#[test]
+fn split_keeps_field_value_via_widget_parent_but_drops_field_kids() {
+    // A SPLIT signature field (value on the field node, widgets as /Kids on
+    // several pages): the widget's /Parent must stay followable — it carries
+    // the /V signature dictionary — but the field's /Kids would drag sibling
+    // widgets from other pages into the output, so it is dropped.
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("split-field.pdf");
+
+    let mut document = Document::with_version("1.7");
+    let catalog_id = document.new_object_id();
+    let pages_id = document.new_object_id();
+    let page1_id = document.new_object_id();
+    let page2_id = document.new_object_id();
+    let field_id = document.new_object_id();
+
+    let sig_dict_id = document.add_object(dictionary! {
+        "Type" => "Sig",
+        "ByteRange" => Object::Array(vec![0.into(), 100.into(), 200.into(), 50.into()]),
+    });
+    let widget1_id = document.add_object(dictionary! {
+        "Type" => "Annot",
+        "Subtype" => "Widget",
+        "Rect" => Object::Array(vec![0.into(), 0.into(), 50.into(), 20.into()]),
+        "P" => Object::Reference(page1_id),
+        "Parent" => Object::Reference(field_id),
+    });
+    let widget2_id = document.add_object(dictionary! {
+        "Type" => "Annot",
+        "Subtype" => "Widget",
+        "Rect" => Object::Array(vec![0.into(), 0.into(), 50.into(), 20.into()]),
+        "P" => Object::Reference(page2_id),
+        "Parent" => Object::Reference(field_id),
+    });
+    document.objects.insert(
+        field_id,
+        dictionary! {
+            "FT" => "Sig",
+            "T" => Object::string_literal("assinatura"),
+            "V" => Object::Reference(sig_dict_id),
+            "Kids" => Object::Array(vec![
+                Object::Reference(widget1_id),
+                Object::Reference(widget2_id),
+            ]),
+        }
+        .into(),
+    );
+
+    for (page_id, widget_id) in [(page1_id, widget1_id), (page2_id, widget2_id)] {
+        let content_id = document.add_object(Object::Stream(Stream::new(
+            Dictionary::new(),
+            b"q Q".to_vec(),
+        )));
+        document.objects.insert(
+            page_id,
+            dictionary! {
+                "Type" => "Page",
+                "Parent" => pages_id,
+                "MediaBox" => Object::Array(vec![0.into(), 0.into(), 100.into(), 100.into()]),
+                "Resources" => dictionary! {},
+                "Contents" => content_id,
+                "Annots" => Object::Array(vec![Object::Reference(widget_id)]),
+            }
+            .into(),
+        );
+    }
+    document.objects.insert(
+        pages_id,
+        dictionary! {
+            "Type" => "Pages",
+            "Kids" => Object::Array(vec![
+                Object::Reference(page1_id),
+                Object::Reference(page2_id),
+            ]),
+            "Count" => 2,
+        }
+        .into(),
+    );
+    document.objects.insert(
+        catalog_id,
+        dictionary! { "Type" => "Catalog", "Pages" => pages_id }.into(),
+    );
+    document.trailer.set("Root", catalog_id);
+    document.save(&input).unwrap();
+
+    let output = temp.path().join("page-1.pdf");
+    split(
+        &input,
+        &[SplitOutput {
+            range: PageRangeGroup::parse("1").unwrap(),
+            path: output.clone(),
+        }],
+    )
+    .unwrap();
+
+    let document = Document::load(&output).unwrap();
+    let pages = document.get_pages();
+    assert_eq!(pages.len(), 1);
+    let page = document.get_dictionary(pages[&1]).unwrap();
+    let annots = page.get(b"Annots").unwrap().as_array().unwrap();
+    let widget = resolve_to_dict(&document, &annots[0]);
+
+    // /Parent → field survives with the signature value…
+    let field = resolve_to_dict(&document, widget.get(b"Parent").unwrap());
+    let signature = resolve_to_dict(&document, field.get(b"V").unwrap());
+    assert_eq!(
+        signature
+            .get(b"ByteRange")
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .len(),
+        4
+    );
+    // …but /Kids is dropped, and with it page 2's sibling widget.
+    assert!(field.get(b"Kids").is_err(), "field /Kids must be dropped");
+    let widget_count = document
+        .objects
+        .values()
+        .filter(|object| {
+            object.as_dict().is_ok_and(|dictionary| {
+                dictionary.get(b"Subtype").and_then(Object::as_name).ok() == Some(b"Widget")
+            })
+        })
+        .count();
+    assert_eq!(widget_count, 1, "sibling widgets must not leak");
+
+    QpdfValidator::detect().validate(&output, 1);
+}

--- a/tests/split_merge.rs
+++ b/tests/split_merge.rs
@@ -1666,11 +1666,10 @@ fn assert_resource_keys(resources: &lopdf::Dictionary, key: &[u8], expected: &[&
     );
 }
 
-/// Two-page fixture rich in document-level metadata and annotations, shaped
-/// like a digitally signed Brazilian court document: trailer `/Info`, catalog
-/// XMP `/Metadata`, and page 1 carrying a URI link, a signature widget whose
-/// `/V` holds a `/ByteRange` + DocMDP `SigRef` (with a `/Data` backreference
-/// to the catalog), and a GoTo link whose destination points at page 2.
+/// Two-page fixture shaped like a digitally signed document: trailer `/Info`,
+/// catalog XMP `/Metadata`, and page 1 carrying a URI link, a signature
+/// widget (with a DocMDP `/Data` backreference to the catalog), and a GoTo
+/// link pointing at page 2.
 fn write_metadata_rich_pdf(path: &Path, author: &str) {
     let mut document = Document::with_version("1.7");
     let catalog_id = document.new_object_id();
@@ -1698,8 +1697,7 @@ fn write_metadata_rich_pdf(path: &Path, author: &str) {
     let sig_ref_id = document.add_object(dictionary! {
         "Type" => "SigRef",
         "TransformMethod" => "DocMDP",
-        // A DocMDP /Data backreference to the catalog: following it from a
-        // page-subset copy would pull the whole document.
+        // Following this from a page-subset copy would pull the whole document.
         "Data" => Object::Reference(catalog_id),
     });
     let sig_dict_id = document.add_object(dictionary! {
@@ -1854,10 +1852,8 @@ fn split_preserves_document_metadata_and_sanitized_annotations() {
         b"URI"
     );
 
-    // The signature widget keeps its /V signature dictionary (ByteRange and
-    // all), its /P is remapped to the output page, and the DocMDP /Data
-    // backreference to the catalog is sanitized to null instead of pulling
-    // the whole source document into the output.
+    // The signature widget keeps its /V dictionary, its /P is remapped to the
+    // output page, and the DocMDP /Data backreference is nulled.
     let sig_widget = resolve_to_dict(&document, &annots[1]);
     assert_eq!(sig_widget.get(b"P").unwrap(), &Object::Reference(pages[&1]));
     let sig_dict = resolve_to_dict(&document, sig_widget.get(b"V").unwrap());
@@ -1876,9 +1872,8 @@ fn split_preserves_document_metadata_and_sanitized_annotations() {
     );
     assert_eq!(sig_ref.get(b"Data").unwrap(), &Object::Null);
 
-    // The GoTo link's destination pointed at page 2, which is not part of
-    // this output: the page reference is nulled, and no second page object
-    // leaks into the output.
+    // The GoTo destination pointed at page 2, which is not in this output:
+    // the reference is nulled and no second page object leaks in.
     let goto_link = resolve_to_dict(&document, &annots[2]);
     let dest = goto_link.get(b"Dest").unwrap().as_array().unwrap();
     assert_eq!(dest[0], Object::Null);
@@ -1955,10 +1950,10 @@ fn merge_takes_document_metadata_from_first_input() {
 
 #[test]
 fn split_keeps_field_value_via_widget_parent_but_drops_field_kids() {
-    // A SPLIT signature field (value on the field node, widgets as /Kids on
-    // several pages): the widget's /Parent must stay followable — it carries
-    // the /V signature dictionary — but the field's /Kids would drag sibling
-    // widgets from other pages into the output, so it is dropped.
+    // A split signature field (value on the field node, widgets as /Kids on
+    // several pages): the widget's /Parent stays followable since it carries
+    // /V, but the field's /Kids is dropped so sibling widgets from other
+    // pages don't leak into the output.
     let temp = tempdir().unwrap();
     let input = temp.path().join("split-field.pdf");
 

--- a/tests/split_merge.rs
+++ b/tests/split_merge.rs
@@ -1665,3 +1665,282 @@ fn assert_resource_keys(resources: &lopdf::Dictionary, key: &[u8], expected: &[&
         path.display()
     );
 }
+
+/// Two-page fixture rich in document-level metadata and annotations, shaped
+/// like a digitally signed Brazilian court document: trailer `/Info`, catalog
+/// XMP `/Metadata`, and page 1 carrying a URI link, a signature widget whose
+/// `/V` holds a `/ByteRange` + DocMDP `SigRef` (with a `/Data` backreference
+/// to the catalog), and a GoTo link whose destination points at page 2.
+fn write_metadata_rich_pdf(path: &Path, author: &str) {
+    let mut document = Document::with_version("1.7");
+    let catalog_id = document.new_object_id();
+    let pages_id = document.new_object_id();
+    let page1_id = document.new_object_id();
+    let page2_id = document.new_object_id();
+
+    let info_id = document.add_object(dictionary! {
+        "Author" => Object::string_literal(author),
+        "Producer" => Object::string_literal("Microsoft Word"),
+        "CreationDate" => Object::string_literal("D:20250219161350-03'00'"),
+    });
+    let xmp_id = document.add_object(Object::Stream(Stream::new(
+        dictionary! { "Type" => "Metadata", "Subtype" => "XML" },
+        b"<?xpacket begin=\"\"?><x:xmpmeta xmlns:x=\"adobe:ns:meta/\"/><?xpacket end=\"w\"?>"
+            .to_vec(),
+    )));
+
+    let uri_link_id = document.add_object(dictionary! {
+        "Type" => "Annot",
+        "Subtype" => "Link",
+        "Rect" => Object::Array(vec![0.into(), 0.into(), 50.into(), 20.into()]),
+        "A" => dictionary! { "S" => "URI", "URI" => Object::string_literal("mailto:someone@example.com") },
+    });
+    let sig_ref_id = document.add_object(dictionary! {
+        "Type" => "SigRef",
+        "TransformMethod" => "DocMDP",
+        // A DocMDP /Data backreference to the catalog: following it from a
+        // page-subset copy would pull the whole document.
+        "Data" => Object::Reference(catalog_id),
+    });
+    let sig_dict_id = document.add_object(dictionary! {
+        "Type" => "Sig",
+        "Filter" => "Adobe.PPKLite",
+        "SubFilter" => "adbe.pkcs7.detached",
+        "ByteRange" => Object::Array(vec![0.into(), 100.into(), 200.into(), 50.into()]),
+        "Contents" => Object::String(vec![0u8; 16], lopdf::StringFormat::Hexadecimal),
+        "Reference" => Object::Array(vec![Object::Reference(sig_ref_id)]),
+    });
+    let sig_widget_id = document.add_object(dictionary! {
+        "Type" => "Annot",
+        "Subtype" => "Widget",
+        "FT" => "Sig",
+        "Rect" => Object::Array(vec![88.into(), 178.into(), 253.into(), 223.into()]),
+        "F" => 132,
+        "P" => Object::Reference(page1_id),
+        "V" => Object::Reference(sig_dict_id),
+    });
+    let goto_page2_id = document.add_object(dictionary! {
+        "Type" => "Annot",
+        "Subtype" => "Link",
+        "Rect" => Object::Array(vec![0.into(), 30.into(), 50.into(), 50.into()]),
+        "Dest" => Object::Array(vec![Object::Reference(page2_id), "Fit".into()]),
+    });
+
+    for (page_id, annots) in [
+        (
+            page1_id,
+            vec![
+                Object::Reference(uri_link_id),
+                Object::Reference(sig_widget_id),
+                Object::Reference(goto_page2_id),
+            ],
+        ),
+        (page2_id, vec![]),
+    ] {
+        let content_id = document.add_object(Object::Stream(Stream::new(
+            Dictionary::new(),
+            b"q Q".to_vec(),
+        )));
+        let mut page = dictionary! {
+            "Type" => "Page",
+            "Parent" => pages_id,
+            "MediaBox" => Object::Array(vec![0.into(), 0.into(), 100.into(), 100.into()]),
+            "Resources" => dictionary! {},
+            "Contents" => content_id,
+        };
+        if !annots.is_empty() {
+            page.set("Annots", Object::Array(annots));
+        }
+        document.objects.insert(page_id, page.into());
+    }
+
+    document.objects.insert(
+        pages_id,
+        dictionary! {
+            "Type" => "Pages",
+            "Kids" => Object::Array(vec![
+                Object::Reference(page1_id),
+                Object::Reference(page2_id),
+            ]),
+            "Count" => 2,
+        }
+        .into(),
+    );
+    document.objects.insert(
+        catalog_id,
+        dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+            "Metadata" => Object::Reference(xmp_id),
+        }
+        .into(),
+    );
+    document.trailer.set("Root", catalog_id);
+    document.trailer.set("Info", Object::Reference(info_id));
+    document
+        .save(path)
+        .unwrap_or_else(|err| panic!("failed to save metadata-rich fixture: {err}"));
+}
+
+fn resolve_to_dict<'a>(document: &'a Document, value: &Object) -> &'a Dictionary {
+    match value {
+        Object::Reference(id) => document.get_object(*id).unwrap().as_dict().unwrap(),
+        _ => panic!("expected an indirect reference, got {value:?}"),
+    }
+}
+
+fn author_of(document: &Document) -> String {
+    let info = document.trailer.get(b"Info").expect("output must carry /Info");
+    let author = resolve_to_dict(document, info).get(b"Author").unwrap();
+    String::from_utf8_lossy(author.as_str().unwrap()).into_owned()
+}
+
+fn xmp_content_of(document: &Document) -> Vec<u8> {
+    let catalog = document.catalog().unwrap();
+    let metadata = catalog
+        .get(b"Metadata")
+        .expect("output catalog must carry /Metadata");
+    let Object::Reference(id) = metadata else {
+        panic!("catalog /Metadata should be an indirect reference");
+    };
+    let Object::Stream(stream) = document.get_object(*id).unwrap() else {
+        panic!("catalog /Metadata should resolve to a stream");
+    };
+    stream.content.clone()
+}
+
+#[test]
+fn split_preserves_document_metadata_and_sanitized_annotations() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("metadata-rich.pdf");
+    write_metadata_rich_pdf(&input, "Marykeller Mello");
+    let output = temp.path().join("page-1.pdf");
+
+    split(
+        &input,
+        &[SplitOutput {
+            range: PageRangeGroup::parse("1").unwrap(),
+            path: output.clone(),
+        }],
+    )
+    .unwrap();
+
+    let document = Document::load(&output).unwrap();
+    let pages = document.get_pages();
+    assert_eq!(pages.len(), 1);
+
+    // Document metadata survives the split.
+    assert_eq!(author_of(&document), "Marykeller Mello");
+    assert!(xmp_content_of(&document).starts_with(b"<?xpacket"));
+
+    // All three annotations survive.
+    let page = document.get_dictionary(pages[&1]).unwrap();
+    let annots = page.get(b"Annots").unwrap().as_array().unwrap();
+    assert_eq!(annots.len(), 3);
+
+    let uri_link = resolve_to_dict(&document, &annots[0]);
+    assert_eq!(
+        uri_link
+            .get(b"A")
+            .unwrap()
+            .as_dict()
+            .unwrap()
+            .get(b"S")
+            .and_then(Object::as_name)
+            .unwrap(),
+        b"URI"
+    );
+
+    // The signature widget keeps its /V signature dictionary (ByteRange and
+    // all), its /P is remapped to the output page, and the DocMDP /Data
+    // backreference to the catalog is sanitized to null instead of pulling
+    // the whole source document into the output.
+    let sig_widget = resolve_to_dict(&document, &annots[1]);
+    assert_eq!(sig_widget.get(b"P").unwrap(), &Object::Reference(pages[&1]));
+    let sig_dict = resolve_to_dict(&document, sig_widget.get(b"V").unwrap());
+    assert_eq!(
+        sig_dict.get(b"ByteRange").unwrap().as_array().unwrap().len(),
+        4
+    );
+    let sig_ref = resolve_to_dict(
+        &document,
+        &sig_dict.get(b"Reference").unwrap().as_array().unwrap()[0],
+    );
+    assert_eq!(sig_ref.get(b"Data").unwrap(), &Object::Null);
+
+    // The GoTo link's destination pointed at page 2, which is not part of
+    // this output: the page reference is nulled, and no second page object
+    // leaks into the output.
+    let goto_link = resolve_to_dict(&document, &annots[2]);
+    let dest = goto_link.get(b"Dest").unwrap().as_array().unwrap();
+    assert_eq!(dest[0], Object::Null);
+    let page_objects = document
+        .objects
+        .values()
+        .filter(|object| {
+            object
+                .as_dict()
+                .is_ok_and(|dictionary| dictionary.has_type(b"Page"))
+        })
+        .count();
+    assert_eq!(page_objects, 1, "page 2 must not leak into the output");
+
+    QpdfValidator::detect().validate(&output, 1);
+}
+
+#[test]
+fn split_pages_outputs_carry_document_metadata() {
+    let temp = tempdir().unwrap();
+    let input = temp.path().join("metadata-rich.pdf");
+    write_metadata_rich_pdf(&input, "Marykeller Mello");
+    let pattern = temp.path().join("page-%d.pdf");
+
+    split_pages(&input, pattern.to_str().unwrap()).unwrap();
+
+    for page in 1..=2 {
+        let document = Document::load(temp.path().join(format!("page-{page}.pdf"))).unwrap();
+        assert_eq!(author_of(&document), "Marykeller Mello");
+        assert!(xmp_content_of(&document).starts_with(b"<?xpacket"));
+    }
+}
+
+#[test]
+fn merge_takes_document_metadata_from_first_input() {
+    let temp = tempdir().unwrap();
+    let first = temp.path().join("first.pdf");
+    let second = temp.path().join("second.pdf");
+    write_metadata_rich_pdf(&first, "First Author");
+    write_metadata_rich_pdf(&second, "Second Author");
+
+    // Whole-input merge takes the streaming path.
+    let streamed = temp.path().join("streamed.pdf");
+    merge(
+        &[MergeInput::all(&first), MergeInput::all(&second)],
+        &streamed,
+    )
+    .unwrap();
+    let document = Document::load(&streamed).unwrap();
+    assert_eq!(document.get_pages().len(), 4);
+    assert_eq!(author_of(&document), "First Author");
+    assert!(xmp_content_of(&document).starts_with(b"<?xpacket"));
+    QpdfValidator::detect().validate(&streamed, 4);
+
+    // A ranged merge takes the eager per-input path; same convention.
+    let ranged = temp.path().join("ranged.pdf");
+    merge(
+        &[
+            MergeInput {
+                path: first.clone(),
+                ranges: vec![PageRangeGroup::parse("1").unwrap()],
+            },
+            MergeInput::all(&second),
+        ],
+        &ranged,
+    )
+    .unwrap();
+    let document = Document::load(&ranged).unwrap();
+    assert_eq!(document.get_pages().len(), 3);
+    assert_eq!(author_of(&document), "First Author");
+    assert!(xmp_content_of(&document).starts_with(b"<?xpacket"));
+    QpdfValidator::detect().validate(&ranged, 3);
+}


### PR DESCRIPTION
## What

- Page annotations are now copied by default (`CopyOptions::copy_annotations = true`) in `split`, `split-pages` (including the template path) and `merge` (including streaming): links, form widgets and signature appearances (the visible gov.br stamp) are real page content and were disappearing from outputs.
- Annotation references into document structure are sanitized to `null` during the copy: a `/Dest` to a page outside the output, or a DocMDP `/Data` backreference to the catalog, can never pull unrelated pages (or the whole document) into a subset. The legitimate `/P` backref and destinations to the output's own pages are remapped normally. AcroForm field nodes reached through a widget's `/Parent` keep their `/V` value but drop `/Kids`, so sibling widgets from other pages don't leak in.
- The trailer `/Info` (author, producer, dates) and the catalog's XMP `/Metadata` stream are copied to split and merge outputs (in merge, the first input donates the metadata, following qpdf's convention). Copying is best-effort: damaged metadata never fails the operation.
- README documents the new behavior; `pje_like_split_pages_keeps_drawn_filter_zoo_and_drops_annots` updated to the new contract, plus 3 new tests (split with a metadata/signature-rich fixture, split-pages, merge).

## Why

Documents extracted by doc-api were losing their digital signature and all forensic metadata (CGV case: a power of attorney signed on gov.br came out of the pipeline with no `/Info`, no XMP and no visible signature stamp, so antifraud classified it as unsigned). Validated with the real PDF: the split output now carries `/Info`, XMP, the `/FT/Sig` widget with `ByteRange`/DocMDP, and renders byte-identical to the original via `pdq render`.

## Notes

- An embedded signature survives as data but does not remain valid on a page subset: the `ByteRange` covers the original file's bytes and any re-serialization changes them. This is a mathematical limitation, not this PR's; the "range = whole document" case is handled in doc-api by delegating to single-input `pdq merge` (existing byte-copy path).
- `/AcroForm` reconstruction (so viewers list the field in the signatures panel) is out of scope; possible follow-up.
- Full `cargo test` green (178 tests) and `cargo clippy --all-targets` clean.
