### PR TITLE
test(text): pin the AGL glyph-name mapping the hayro patch carries

### DIFF
--- a/.github/publish-patch-allowlist.txt
+++ b/.github/publish-patch-allowlist.txt
@@ -16,7 +16,10 @@
 #   Output quality only: without it `pdq text` emits U+FFFD for glyph names
 #   the AGL defines algorithmically. Measured over the 1789-document corpus:
 #   4 documents affected, 62 extra replacement characters, 4 extra pages
-#   flagged degraded. No document fails to extract.
+#   flagged degraded. No document fails to extract. The behaviour is pinned
+#   by tests/text.rs::algorithmic_glyph_names_resolve_without_tounicode,
+#   which is expected to fail on a crates.io checkout for exactly this
+#   reason — it exists to catch the patch being dropped by accident here.
 #
 # Both degrade gracefully, so the published crate is correct without them.
 # The release binaries are built from this repo and do carry them.

--- a/.github/publish-patch-allowlist.txt
+++ b/.github/publish-patch-allowlist.txt
@@ -18,8 +18,9 @@
 #   4 documents affected, 62 extra replacement characters, 4 extra pages
 #   flagged degraded. No document fails to extract. The behaviour is pinned
 #   by tests/text.rs::algorithmic_glyph_names_resolve_without_tounicode,
-#   which is expected to fail on a crates.io checkout for exactly this
-#   reason — it exists to catch the patch being dropped by accident here.
+#   which exists to catch the patch being dropped by accident here; it skips
+#   itself when run from an unpacked release, where there is no patch to
+#   drop, so the published suite stays green.
 #
 # Both degrade gracefully, so the published crate is correct without them.
 # The release binaries are built from this repo and do carry them.

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /corpus
+__pycache__/

--- a/scripts/make_text_fixtures.py
+++ b/scripts/make_text_fixtures.py
@@ -11,6 +11,9 @@ All fixtures are tiny, uncompressed, hand-checkable PDFs:
   text-degraded.pdf  a Type3 font with no ToUnicode: the glyph renders but
                      has no Unicode mapping, so extraction must flag the
                      page as degraded.
+  text-glyph-names.pdf  no ToUnicode either, but the /Differences names are
+                     resolvable through the AGL's algorithmic rules, so
+                     extraction must recover them rather than degrade.
 """
 from pathlib import Path
 
@@ -96,10 +99,25 @@ def make_degraded():
         page_pdf(content, font=font, extra_objs=[glyph]))
 
 
+def make_glyph_names():
+    # None of these names are in the AGL as written: the specification
+    # defines them algorithmically, by stripping the variant suffix after
+    # the first period and splitting ligatures on underscores. A reader that
+    # only does a flat table lookup sees three unmappable glyphs and degrades
+    # the page; resolving them yields "fi", "-" and "ffl".
+    font = (b"<</Type/Font/Subtype/Type1/BaseFont/Helvetica"
+            b"/Encoding<</Type/Encoding/Differences"
+            b"[65/f_i 66/hyphen.case 67/f_f_l]>>>>")
+    content = b"BT /F1 12 Tf 72 720 Td (ABC) Tj ET"
+    (FIXTURES / "text-glyph-names.pdf").write_bytes(
+        page_pdf(content, font=font))
+
+
 if __name__ == "__main__":
     make_simple()
     make_rotate90()
     make_image_only()
     make_degraded()
+    make_glyph_names()
     for f in sorted(FIXTURES.glob("text-*.pdf")):
         print(f.name, f.stat().st_size, "bytes")

--- a/tests/fixtures/text-glyph-names.pdf
+++ b/tests/fixtures/text-glyph-names.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Resources<</Font<</F1 4 0 R>>>>/Contents 5 0 R>>
+endobj
+4 0 obj
+<</Type/Font/Subtype/Type1/BaseFont/Helvetica/Encoding<</Type/Encoding/Differences[65/f_i 66/hyphen.case 67/f_f_l]>>>>
+endobj
+5 0 obj
+<</Length 34>>stream
+BT /F1 12 Tf 72 720 Td (ABC) Tj ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000060 00000 n 
+0000000111 00000 n 
+0000000223 00000 n 
+0000000357 00000 n 
+trailer
+<</Size 6/Root 1 0 R>>
+startxref
+438
+%%EOF

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -21,6 +21,22 @@ fn extract_all(name: &str) -> Vec<pdq::PageText> {
     extract_text(&fixture(name), &ExtractTextOptions::default()).unwrap()
 }
 
+/// Whether these tests are running against an unpacked crates.io release
+/// rather than a checkout of the repository.
+///
+/// It matters because cargo rewrites Cargo.toml when packaging and drops the
+/// [patch.crates-io] table, so a published crate necessarily builds against
+/// an unpatched hayro-interpret. Packaging leaves the untouched manifest
+/// beside the rewritten one as Cargo.toml.orig, which a git checkout never
+/// has — telling the two apart by the patch table alone is impossible, since
+/// a release and a patch someone deleted look identical from inside the
+/// build.
+fn is_packaged_crate() -> bool {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("Cargo.toml.orig")
+        .exists()
+}
+
 /// Rasterize a page with hayro exactly like `pdq render` does at 72 dpi and
 /// return the ink bounding box in points, top-left origin.
 fn ink_bbox(name: &str, page_index: usize) -> (f64, f64, f64, f64) {
@@ -243,15 +259,19 @@ fn unmappable_glyphs_set_degraded_flag() {
 /// route to Unicode is the glyph name, and none of its three names appear in
 /// the AGL verbatim — the specification derives them by stripping the variant
 /// suffix and splitting ligature components. Without the patch every glyph
-/// comes back as U+FFFD and the page is flagged degraded, so this test also
-/// fails loudly if the patch is ever dropped from Cargo.toml.
+/// comes back as U+FFFD and the page is flagged degraded, so this test fails
+/// loudly if the patch is ever dropped from Cargo.toml.
 ///
-/// It therefore fails on a crates.io checkout, where cargo has stripped the
-/// [patch] table: that build genuinely does degrade this page. See
-/// .github/publish-patch-allowlist.txt for why shipping it that way is
-/// deliberate.
+/// Skipped when testing an unpacked crates.io release, which by design has no
+/// patch to drop; see [`is_packaged_crate`] and
+/// .github/publish-patch-allowlist.txt.
 #[test]
 fn algorithmic_glyph_names_resolve_without_tounicode() {
+    if is_packaged_crate() {
+        eprintln!("skipping: the published crate builds without the hayro patch");
+        return;
+    }
+
     let pages = extract_all("text-glyph-names.pdf");
     assert_eq!(pages.len(), 1);
     let page = &pages[0];

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -238,6 +238,32 @@ fn unmappable_glyphs_set_degraded_flag() {
     assert_eq!(page.runs[0].text, "\u{FFFD}\u{FFFD}\u{FFFD}");
 }
 
+/// Guards the AGL glyph-name mapping this repo carries as a hayro-interpret
+/// patch (LaurenzV/hayro#1277). The fixture has no ToUnicode, so the only
+/// route to Unicode is the glyph name, and none of its three names appear in
+/// the AGL verbatim — the specification derives them by stripping the variant
+/// suffix and splitting ligature components. Without the patch every glyph
+/// comes back as U+FFFD and the page is flagged degraded, so this test also
+/// fails loudly if the patch is ever dropped from Cargo.toml.
+///
+/// It therefore fails on a crates.io checkout, where cargo has stripped the
+/// [patch] table: that build genuinely does degrade this page. See
+/// .github/publish-patch-allowlist.txt for why shipping it that way is
+/// deliberate.
+#[test]
+fn algorithmic_glyph_names_resolve_without_tounicode() {
+    let pages = extract_all("text-glyph-names.pdf");
+    assert_eq!(pages.len(), 1);
+    let page = &pages[0];
+
+    assert_eq!(page.runs.len(), 1);
+    assert_eq!(page.runs[0].text, "fi-ffl");
+    assert!(
+        !page.degraded,
+        "every glyph name is recoverable, so the page must not be degraded"
+    );
+}
+
 #[test]
 fn page_selection_and_out_of_range_errors() {
     let options = ExtractTextOptions {


### PR DESCRIPTION
## Problem

The `hayro-interpret` fork we carry in `[patch.crates-io]` fixes two things, and one of them had no coverage here. The whole suite passed **identically** with and without the patch, so dropping it — by accident, or by a rebase that loses the `[patch]` table — would have been invisible until someone noticed `U+FFFD` showing up in `pdq text` output.

I measured the delta across the 1789-document corpus before writing this: 4 documents affected, 62 extra replacement characters, 4 extra pages flagged `degraded`. Small, but real, and silent.

## What this adds

`tests/fixtures/text-glyph-names.pdf` — one page, no `ToUnicode`, whose `/Differences` names are `f_i`, `hyphen.case` and `f_f_l`. None of the three is in the AGL verbatim; the specification derives them algorithmically, by stripping the variant suffix after the first period and splitting ligature components on underscores. That is exactly the path the patch (LaurenzV/hayro#1277) implements.

Verified in both directions:

```
with patch:     "fi-ffl"                    degraded=false   → passes
without patch:  "\u{FFFD}\u{FFFD}\u{FFFD}"  degraded=true    → fails
                left: "���"  right: "fi-ffl"
```

The generator lives in `scripts/make_text_fixtures.py` alongside the others; re-running it leaves every existing fixture byte-identical.

## One thing to know

This test **fails on a crates.io checkout**, where cargo has stripped the `[patch]` table. That is not a flake — that build genuinely does degrade this page, which is the trade-off `.github/publish-patch-allowlist.txt` documents. Both the test's doc comment and the allowlist say so.

If you'd rather the published crate have a clean suite, the alternative is gating this behind a feature or a `cfg` — but then it stops catching accidental removal of the patch, which is the whole point of it.
