### PR TITLE
feat(text): extract annotation and form-field text by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ with a real user password cannot be rendered.
 ### `pdq text` — positioned text runs as JSON
 
 ```sh
-pdq text [--pages RANGES] [--password PW] input.pdf
+pdq text [--pages RANGES] [--password PW] [--no-annotations] input.pdf
 ```
 
 Extracts each selected page's text runs with their positions, using the same
@@ -263,12 +263,20 @@ hayro interpreter `render` uses, and prints a JSON array to stdout:
   0.1–0.6 em past a glyph's advance becomes `' '`, anything wider starts a
   new run.
 - A scanned/image-only page succeeds with `"runs": []`.
-- **`degraded: true`** flags pages where at least one visible glyph could
-  not be mapped to Unicode (it is emitted as U+FFFD instead of being
-  silently dropped) — the caller can distinguish "extraction failed" from
-  "no text on page", which pdf.js's `getTextContent` cannot signal.
+- **`degraded: true`** flags pages whose text is known to be incomplete:
+  at least one visible glyph could not be mapped to Unicode (it is emitted as
+  U+FFFD instead of being silently dropped), or the page's annotation layer
+  was skipped (see below). The caller can distinguish "extraction failed"
+  from "no text on page", which pdf.js's `getTextContent` cannot signal.
 - Invisible text (render mode 3, e.g. OCR layers under scanned pages) is
-  extracted; annotation appearance streams are not.
+  extracted.
+- Annotation and form-field appearance streams are extracted too, like
+  `pdftotext` and `mutool draw -F txt` do: a filled text widget's value comes
+  back as a run positioned at the widget. `--no-annotations` restricts the
+  output to the page content stream. Hidden annotations are always excluded,
+  an annotation with no `/AP` yields no text, and a page carrying an
+  implausible number of them has the layer skipped and is marked `degraded`
+  — `src/text.rs` documents the exact bounds.
 
 `text` is behind the `text` cargo feature (on by default) and, unlike
 `render`, takes `--password` for encrypted inputs.
@@ -492,7 +500,8 @@ Encrypted inputs go through the `*_with_password` variants
 structs (`SplitPagesOptions`, `MergeOptions`). Rendering is
 `pdq::render_pages` with `RenderOptions { dpi, pages }`, behind the `render`
 feature. Text extraction is `pdq::extract_text` with `ExtractTextOptions
-{ pages, password }`, returning `Vec<PageText>`, behind the `text` feature.
+{ pages, password, annotations }`, returning `Vec<PageText>`, behind the
+`text` feature.
 
 ### Feature flags and MSRV
 

--- a/scripts/make_text_fixtures.py
+++ b/scripts/make_text_fixtures.py
@@ -14,6 +14,10 @@ All fixtures are tiny, uncompressed, hand-checkable PDFs:
   text-glyph-names.pdf  no ToUnicode either, but the /Differences names are
                      resolvable through the AGL's algorithmic rules, so
                      extraction must recover them rather than degrade.
+  text-annotations.pdf  one page word plus three /Widget annotations whose
+                     /AP /N appearance streams each draw a distinct word:
+                     a normal one (/F 4), a Hidden one (/F 2) and a NoView
+                     one (/F 32).
 """
 from pathlib import Path
 
@@ -113,11 +117,39 @@ def make_glyph_names():
         page_pdf(content, font=font))
 
 
+def make_annotations():
+    # Widget appearance streams are form XObjects placed at the annotation's
+    # /Rect, so each word lands inside its own widget rectangle. The flags
+    # are the three cases text extraction has to distinguish: 4 = Print,
+    # 2 = Hidden (never extracted), 32 = NoView (poppler and mupdf suppress
+    # it, hayro does not).
+    def widget(rect: bytes, flags: int, ap: int) -> bytes:
+        return (b"<</Type/Annot/Subtype/Widget/FT/Tx/T(field%d)"
+                b"/Rect[%s]/F %d/AP<</N %d 0 R>>>>" % (ap, rect, flags, ap))
+
+    def appearance(word: bytes) -> bytes:
+        return stream(
+            b"/Type/XObject/Subtype/Form/BBox[0 0 100 20]"
+            b"/Resources<</Font<</F1 4 0 R>>>>",
+            b"BT /F1 12 Tf 2 4 Td (%s) Tj ET" % word)
+
+    content = b"BT /F1 18 Tf 72 720 Td (Content) Tj ET"
+    (FIXTURES / "text-annotations.pdf").write_bytes(page_pdf(
+        content,
+        extra_page=b"/Annots[6 0 R 8 0 R 10 0 R]",
+        extra_objs=[
+            widget(b"200 600 300 620", 4, 7), appearance(b"Filled"),
+            widget(b"200 560 300 580", 2, 9), appearance(b"Hidden"),
+            widget(b"200 520 300 540", 32, 11), appearance(b"Noview"),
+        ]))
+
+
 if __name__ == "__main__":
     make_simple()
     make_rotate90()
     make_image_only()
     make_degraded()
     make_glyph_names()
+    make_annotations()
     for f in sorted(FIXTURES.glob("text-*.pdf")):
         print(f.name, f.stat().st_size, "bytes")

--- a/src/bin/pdq.rs
+++ b/src/bin/pdq.rs
@@ -128,6 +128,10 @@ struct TextArgs {
     /// Password for encrypted inputs
     #[arg(long, value_name = "PASSWORD")]
     password: Option<String>,
+
+    /// Skip annotation and form-field appearance streams (page content only)
+    #[arg(long)]
+    no_annotations: bool,
 }
 
 #[cfg(feature = "dhat-heap")]
@@ -196,6 +200,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             let options = pdq::ExtractTextOptions {
                 pages: args.pages.map(PageRangeGroup::parse).transpose()?,
                 password: args.password,
+                annotations: !args.no_annotations,
             };
             let pages = pdq::extract_text(&args.input, &options)?;
             println!("{}", pdq::text::pages_to_json(&pages));

--- a/src/text.rs
+++ b/src/text.rs
@@ -10,7 +10,11 @@ use std::{
 use hayro::hayro_interpret::{
     font::Glyph,
     hayro_cmap::BfString,
-    hayro_syntax::{page::Page, LoadPdfError, Pdf},
+    hayro_syntax::{
+        object::{dict::keys::ANNOTS, Array},
+        page::Page,
+        LoadPdfError, Pdf,
+    },
     interpret_page, BlendMode, ClipPath, Context, Device, GlyphDrawMode, Image, InterpreterCache,
     InterpreterSettings, InterpreterWarning, Paint, PathDrawMode, SoftMask, TransformExt,
 };
@@ -27,6 +31,25 @@ use crate::{
 const ASCENT_FACTOR: f64 = 0.8;
 /// hayro glyph transforms take font units (thousandths of an em) as input.
 const FONT_UNITS_PER_EM: f64 = 1000.0;
+/// Annotations on one page past which their appearance streams are skipped.
+///
+/// hayro-syntax rebuilds an object stream's entire offset table on *every*
+/// object it resolves out of it (`ObjectStream::new` in `xref.rs`), so
+/// resolving a page's annotations costs annotations x objects-in-that-stream.
+/// `corpus/pdfjs/bug1978317.pdf` puts 32,768 `/Link` annotations in a 13 MB
+/// object stream and takes 25 s to yield no text at all, against 93 ms with
+/// annotations off.
+///
+/// The busiest page in the 1,856-file corpus carries 171 annotations, so this
+/// is a 24x margin over anything real; pages past it are link or popup spam,
+/// which by construction has no `/AP` and so contributes no text. Skipping
+/// marks the page [`PageText::degraded`] rather than dropping the fact
+/// silently. It bounds the blowup, it does not remove it — the real fix is a
+/// per-stream offset cache upstream (LaurenzV/hayro), and until that ships
+/// `render` keeps the same pathology, where dropping annotations would change
+/// pixels.
+const MAX_ANNOTATIONS_PER_PAGE: usize = 4_096;
+
 /// Gap past a glyph's advance (in em) that reads as a word space rather than
 /// kerning or tracking, synthesized as ' ' for PDFs that encode word gaps as
 /// TJ offsets instead of space glyphs (LaTeX). Poppler's `minWordBreakSpace`
@@ -37,10 +60,30 @@ const WORD_GAP_MIN: f64 = 0.1;
 /// `SPACE_IN_FLOW_MAX_FACTOR`); anything wider starts a new run.
 const WORD_GAP_MAX: f64 = 0.6;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct ExtractTextOptions {
     pub pages: Option<PageRangeGroup>,
     pub password: Option<String>,
+    /// Include the text of annotation and form-field appearance streams —
+    /// a filled text widget's value, a FreeText note, a stamp — alongside the
+    /// page content stream. Defaults to `true`, matching `pdftotext`,
+    /// `mutool draw -F txt` and pdf-oxide. Annotations flagged Hidden
+    /// (`/F` bit 2) are excluded either way.
+    pub annotations: bool,
+}
+
+impl Default for ExtractTextOptions {
+    fn default() -> Self {
+        Self {
+            pages: None,
+            password: None,
+            // The JSON is the whole output: there is no second layer for a
+            // caller to consult, so dropping appearance streams silently
+            // loses filled-in form values. `CopyOptions::copy_annotations`
+            // defaults to true for the same reason.
+            annotations: true,
+        }
+    }
 }
 
 /// A horizontal (or uniformly-oriented) sequence of glyphs positioned on the
@@ -64,9 +107,11 @@ pub struct PageText {
     pub page: usize,
     pub width: f32,
     pub height: f32,
-    /// True when at least one glyph on the page could not be mapped to
-    /// Unicode (emitted as U+FFFD) or the interpreter reported a font it
-    /// could not decode. Distinguishes "extraction failed" from "no text".
+    /// True when the page's text is known to be incomplete or unreliable: a
+    /// glyph could not be mapped to Unicode (emitted as U+FFFD), the
+    /// interpreter reported a font it could not decode, or the page carried
+    /// more than `MAX_ANNOTATIONS_PER_PAGE` annotations and their appearance
+    /// streams were skipped. Distinguishes "extraction failed" from "no text".
     pub degraded: bool,
     pub runs: Vec<TextRun>,
 }
@@ -89,7 +134,14 @@ fn extract_text_inner(input: &Path, options: &ExtractTextOptions) -> Result<Vec<
     let cache = InterpreterCache::new();
     Ok(selected
         .iter()
-        .map(|&page_number| extract_page(&pages[page_number - 1], page_number, &cache))
+        .map(|&page_number| {
+            extract_page(
+                &pages[page_number - 1],
+                page_number,
+                &cache,
+                options.annotations,
+            )
+        })
         .collect())
 }
 
@@ -113,9 +165,23 @@ fn load_pdf(data: Vec<u8>, password: Option<&str>, input: &Path) -> Result<Pdf> 
     })
 }
 
-fn extract_page<'a>(page: &Page<'a>, page_number: usize, cache: &InterpreterCache<'a>) -> PageText {
+fn extract_page<'a>(
+    page: &Page<'a>,
+    page_number: usize,
+    cache: &InterpreterCache<'a>,
+    annotations: bool,
+) -> PageText {
     let (width, height) = page.render_dimensions();
     let initial_transform = page.initial_transform(true).to_kurbo();
+
+    // Counting is cheap where resolving is not: `raw_iter` walks the array's
+    // bytes and never dereferences the `n 0 R` entries, so this costs
+    // microseconds even on the 32,768-annotation page it exists to catch.
+    let annotation_flood = annotations
+        && page.raw().get::<Array<'_>>(ANNOTS).is_some_and(|annots| {
+            annots.raw_iter().take(MAX_ANNOTATIONS_PER_PAGE + 1).count() > MAX_ANNOTATIONS_PER_PAGE
+        });
+    let annotations = annotations && !annotation_flood;
 
     let font_warning = Arc::new(AtomicBool::new(false));
     let sink_flag = font_warning.clone();
@@ -125,9 +191,14 @@ fn extract_page<'a>(page: &Page<'a>, page_number: usize, cache: &InterpreterCach
                 sink_flag.store(true, Ordering::Relaxed);
             }
         }),
-        // The text layer covers page content only; annotation appearance
-        // streams get their own layer in viewers (pdf.js does the same).
-        render_annotations: false,
+        // Appearance streams carry text that appears nowhere else in the
+        // output — filled form-field values above all — so they are part of
+        // the text layer, as they are for pdftotext and mutool. hayro skips
+        // annotations flagged Hidden (`/F` bit 2) but not NoView (bit 6),
+        // and does not special-case `/Popup`; both are upstream gaps pdq
+        // cannot filter from the outside (the annotation loop is inside
+        // `interpret_page`).
+        render_annotations: annotations,
         ..Default::default()
     };
 
@@ -146,7 +217,7 @@ fn extract_page<'a>(page: &Page<'a>, page_number: usize, cache: &InterpreterCach
         page: page_number,
         width,
         height,
-        degraded: missing_unicode || font_warning.load(Ordering::Relaxed),
+        degraded: missing_unicode || font_warning.load(Ordering::Relaxed) || annotation_flood,
         runs,
     }
 }

--- a/tests/fixtures/text-annotations.pdf
+++ b/tests/fixtures/text-annotations.pdf
@@ -1,0 +1,62 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Resources<</Font<</F1 4 0 R>>>>/Contents 5 0 R/Annots[6 0 R 8 0 R 10 0 R]>>
+endobj
+4 0 obj
+<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>
+endobj
+5 0 obj
+<</Length 38>>stream
+BT /F1 18 Tf 72 720 Td (Content) Tj ET
+endstream
+endobj
+6 0 obj
+<</Type/Annot/Subtype/Widget/FT/Tx/T(field7)/Rect[200 600 300 620]/F 4/AP<</N 7 0 R>>>>
+endobj
+7 0 obj
+<</Type/XObject/Subtype/Form/BBox[0 0 100 20]/Resources<</Font<</F1 4 0 R>>>>/Length 34>>stream
+BT /F1 12 Tf 2 4 Td (Filled) Tj ET
+endstream
+endobj
+8 0 obj
+<</Type/Annot/Subtype/Widget/FT/Tx/T(field9)/Rect[200 560 300 580]/F 2/AP<</N 9 0 R>>>>
+endobj
+9 0 obj
+<</Type/XObject/Subtype/Form/BBox[0 0 100 20]/Resources<</Font<</F1 4 0 R>>>>/Length 34>>stream
+BT /F1 12 Tf 2 4 Td (Hidden) Tj ET
+endstream
+endobj
+10 0 obj
+<</Type/Annot/Subtype/Widget/FT/Tx/T(field11)/Rect[200 520 300 540]/F 32/AP<</N 11 0 R>>>>
+endobj
+11 0 obj
+<</Type/XObject/Subtype/Form/BBox[0 0 100 20]/Resources<</Font<</F1 4 0 R>>>>/Length 34>>stream
+BT /F1 12 Tf 2 4 Td (Noview) Tj ET
+endstream
+endobj
+xref
+0 12
+0000000000 65535 f 
+0000000015 00000 n 
+0000000060 00000 n 
+0000000111 00000 n 
+0000000250 00000 n 
+0000000313 00000 n 
+0000000398 00000 n 
+0000000501 00000 n 
+0000000657 00000 n 
+0000000760 00000 n 
+0000000916 00000 n 
+0000001023 00000 n 
+trailer
+<</Size 12/Root 1 0 R>>
+startxref
+1180
+%%EOF

--- a/tests/text.rs
+++ b/tests/text.rs
@@ -31,6 +31,14 @@ fn corpus_file(relative: &str) -> Option<PathBuf> {
     path.exists().then_some(path)
 }
 
+fn run_texts(pages: &[pdq::PageText]) -> Vec<&str> {
+    pages
+        .iter()
+        .flat_map(|p| &p.runs)
+        .map(|r| r.text.as_str())
+        .collect()
+}
+
 /// Whether these tests are running against an unpacked crates.io release
 /// rather than a checkout of the repository.
 ///
@@ -294,6 +302,131 @@ fn algorithmic_glyph_names_resolve_without_tounicode() {
     );
 }
 
+/// The default must extract appearance-stream text, and it must do so through
+/// `ExtractTextOptions::default()` specifically: a derived `Default` would
+/// leave the flag `false` and silently reinstate the data loss for every
+/// caller, including the CLI.
+#[test]
+fn annotation_appearance_streams_are_extracted_by_default() {
+    let pages = extract_all("text-annotations.pdf");
+    let texts = run_texts(&pages);
+    assert!(texts.contains(&"Content"), "{texts:?}");
+    assert!(texts.contains(&"Filled"), "{texts:?}");
+
+    // The widget's value lands inside the widget's /Rect [200 600 300 620],
+    // converted to the top-left origin the JSON uses.
+    let filled = pages[0]
+        .runs
+        .iter()
+        .find(|r| r.text == "Filled")
+        .expect("filled widget value");
+    assert!(
+        (200.0..=300.0).contains(&filled.x),
+        "filled.x = {}",
+        filled.x
+    );
+    assert!(
+        (792.0 - 620.0..=792.0 - 600.0).contains(&filled.y),
+        "filled.y = {}",
+        filled.y
+    );
+}
+
+/// Hidden annotations (`/F` bit 2) are invisible on the page, so their text
+/// must never reach the output under any option.
+#[test]
+fn hidden_annotations_are_never_extracted() {
+    for annotations in [true, false] {
+        let options = ExtractTextOptions {
+            annotations,
+            ..Default::default()
+        };
+        let pages = extract_text(&fixture("text-annotations.pdf"), &options).unwrap();
+        assert!(
+            !run_texts(&pages).contains(&"Hidden"),
+            "hidden widget extracted with annotations={annotations}"
+        );
+    }
+}
+
+/// Known limitation, pinned deliberately: NoView (`/F` bit 6) annotations are
+/// printed but not displayed, and poppler, mupdf and pdf-oxide all suppress
+/// them. hayro's annotation loop only checks the Hidden bit, and pdq cannot
+/// filter from the outside — the loop is inside `interpret_page` and every
+/// hook it would need is `pub(crate)`. If a hayro upgrade starts honouring
+/// the flag this test fails, which is the point: update it and the README
+/// limitation together rather than letting the two drift.
+#[test]
+fn noview_annotations_are_extracted_as_upstream_does() {
+    let pages = extract_all("text-annotations.pdf");
+    let texts = run_texts(&pages);
+    assert!(texts.contains(&"Noview"), "{texts:?}");
+}
+
+#[test]
+fn annotations_can_be_disabled() {
+    let options = ExtractTextOptions {
+        annotations: false,
+        ..Default::default()
+    };
+    let pages = extract_text(&fixture("text-annotations.pdf"), &options).unwrap();
+    assert_eq!(run_texts(&pages), ["Content"]);
+}
+
+/// Appearance streams are drawn through the same device as page content, so a
+/// widget whose value also appears in the content stream could in principle be
+/// emitted twice. Nothing deduplicates runs, so the absence of overlap is a
+/// property worth holding onto.
+#[test]
+fn annotation_runs_do_not_duplicate_page_content() {
+    let pages = extract_all("text-annotations.pdf");
+    let runs = &pages[0].runs;
+    for (i, a) in runs.iter().enumerate() {
+        for b in &runs[i + 1..] {
+            let overlaps = a.x < b.x + b.width
+                && b.x < a.x + a.width
+                && a.y < b.y + b.height
+                && b.y < a.y + a.height;
+            assert!(
+                !(a.text.trim() == b.text.trim() && overlaps),
+                "run '{}' emitted twice at overlapping positions",
+                a.text
+            );
+        }
+    }
+}
+
+#[test]
+fn text_cli_includes_annotations_unless_opted_out() {
+    let with_annots = pdq()
+        .arg("text")
+        .arg(fixture("text-annotations.pdf"))
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let value: serde_json::Value = serde_json::from_slice(&with_annots).unwrap();
+    let runs = value[0]["runs"].as_array().unwrap();
+    let texts: Vec<&str> = runs.iter().map(|r| r["text"].as_str().unwrap()).collect();
+    assert!(texts.contains(&"Filled"), "{texts:?}");
+    assert!(!texts.contains(&"Hidden"), "{texts:?}");
+
+    let without = pdq()
+        .arg("text")
+        .arg("--no-annotations")
+        .arg(fixture("text-annotations.pdf"))
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let value: serde_json::Value = serde_json::from_slice(&without).unwrap();
+    let runs = value[0]["runs"].as_array().unwrap();
+    let texts: Vec<&str> = runs.iter().map(|r| r["text"].as_str().unwrap()).collect();
+    assert_eq!(texts, ["Content"]);
+}
+
 /// hayro-syntax's object lexer has no recursion cap, so deeply nested
 /// dictionaries used to overflow the stack and abort the process (exit 134,
 /// no unwinding). `corpus/qpdf-qtest/0413-issue-202.pdf` nests its *trailer*
@@ -328,6 +461,107 @@ fn deeply_nested_trailer_extracts_instead_of_aborting() {
     assert!(
         texts.contains(&"Sample PDF Document"),
         "the file extracts real text once the stack is big enough: {texts:?}"
+    );
+}
+
+/// A one-page PDF carrying `count` widget annotations, all sharing one
+/// appearance stream that draws the word "Note", over page content that draws
+/// "Body". Built rather than committed because the interesting counts are in
+/// the thousands.
+fn write_annotation_flood(path: &std::path::Path, count: usize) {
+    const FONT: usize = 4;
+    const APPEARANCE: usize = 5;
+    const CONTENTS: usize = 6;
+    const FIRST_ANNOT: usize = 7;
+
+    let appearance = b"BT /F1 12 Tf 2 4 Td (Note) Tj ET";
+    let contents = b"BT /F1 12 Tf 20 100 Td (Body) Tj ET";
+    let annots = (0..count)
+        .map(|i| format!("{} 0 R", FIRST_ANNOT + i))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let mut bodies = vec![
+        "<</Type/Catalog/Pages 2 0 R>>".to_string(),
+        "<</Type/Pages/Kids[3 0 R]/Count 1>>".to_string(),
+        format!(
+            "<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]/Contents {CONTENTS} 0 R\
+             /Resources<</Font<</F1 {FONT} 0 R>>>>/Annots[{annots}]>>"
+        ),
+        "<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>".to_string(),
+        format!(
+            "<</Type/XObject/Subtype/Form/BBox[0 0 60 20]\
+             /Resources<</Font<</F1 {FONT} 0 R>>>>/Length {}>>\nstream\n{}\nendstream",
+            appearance.len(),
+            String::from_utf8_lossy(appearance)
+        ),
+        format!(
+            "<</Length {}>>\nstream\n{}\nendstream",
+            contents.len(),
+            String::from_utf8_lossy(contents)
+        ),
+    ];
+    bodies.extend((0..count).map(|_| {
+        format!("<</Type/Annot/Subtype/Widget/Rect[10 10 70 30]/F 4/AP<</N {APPEARANCE} 0 R>>>>")
+    }));
+
+    let mut pdf = b"%PDF-1.4\n".to_vec();
+    let mut offsets = Vec::with_capacity(bodies.len());
+    for (index, body) in bodies.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{} 0 obj\n{body}\nendobj\n", index + 1).as_bytes());
+    }
+    let xref_at = pdf.len();
+    pdf.extend_from_slice(
+        format!("xref\n0 {}\n0000000000 65535 f \n", bodies.len() + 1).as_bytes(),
+    );
+    for offset in &offsets {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<</Size {}/Root 1 0 R>>\nstartxref\n{xref_at}\n%%EOF\n",
+            bodies.len() + 1
+        )
+        .as_bytes(),
+    );
+    std::fs::write(path, &pdf).unwrap();
+}
+
+/// A page carrying more annotations than any real document skips their
+/// appearance streams, because hayro-syntax resolves each one by rebuilding
+/// its object stream's whole offset table — 32,768 `/Link` annotations in
+/// `corpus/pdfjs/bug1978317.pdf` cost 25 s and yield no text. Page content is
+/// untouched and the page is marked degraded so the omission is visible.
+#[test]
+fn an_annotation_flood_is_skipped_and_marked_degraded() {
+    let temp = tempfile::tempdir().unwrap();
+
+    let at_cap = temp.path().join("at-cap.pdf");
+    write_annotation_flood(&at_cap, 4_096);
+    let pages = extract_text(&at_cap, &ExtractTextOptions::default()).unwrap();
+    assert!(
+        run_texts(&pages).contains(&"Note"),
+        "the cap itself must still be extracted: {:?}",
+        run_texts(&pages)
+    );
+    assert!(!pages[0].degraded);
+
+    let past_cap = temp.path().join("past-cap.pdf");
+    write_annotation_flood(&past_cap, 4_097);
+    let pages = extract_text(&past_cap, &ExtractTextOptions::default()).unwrap();
+    let texts = run_texts(&pages);
+    assert!(
+        texts.contains(&"Body"),
+        "page content survives the skip: {texts:?}"
+    );
+    assert!(
+        !texts.contains(&"Note"),
+        "annotations past the cap must be skipped: {texts:?}"
+    );
+    assert!(
+        pages[0].degraded,
+        "a skipped annotation layer must be reported, not dropped silently"
     );
 }
 


### PR DESCRIPTION
`pdq text` set render_annotations: false, so appearance-stream text reached
no output at all — a filled text widget's value, a FreeText note, a stamp,
a signature's appearance. For a JSON API feeding document pipelines that is
silent data loss: unlike a viewer, the caller has no second layer to
consult. pdftotext and mutool draw -F txt both include this text.

Benchmarking against pdf-oxide over 1,845 corpus PDFs made it the single
largest category of recall loss. Token recall against a poppler-union-mupdf
reference, before -> after:

  annotation-text-widget.pdf        0.118 -> 0.989   (pdf-oxide 0.720)
  issue18036.pdf                    0.056 -> 1.000   (pdf-oxide 1.000)
  issue17492.pdf                    0.562 -> 0.986   (pdf-oxide 0.918)
  0145-appearances-1-rotated.pdf    0.750 -> 1.000   (pdf-oxide 0.906)
  issue16500.pdf                    0.800 -> 1.000   (pdf-oxide 1.000)

A full re-sweep of all 1,845 files against the previous binary: 120 files
gain text, none lose any, none change status, and no run coordinates or
ordering move. `--no-annotations` restores the old output exactly.

ExtractTextOptions grows an `annotations` field, so Default is now written
out rather than derived — a derived Default would leave the flag false and
reinstate the loss for every library caller, which is what the new test
pins.

MAX_ANNOTATIONS_PER_PAGE caps the blowup from hayro-syntax rebuilding an
object stream's offset table per resolved object: corpus/pdfjs/
bug1978317.pdf hides 32,768 /Link annotations in one object stream and took
25 s to produce no text. Past 4,096 annotations the layer is skipped and the
page is marked degraded rather than dropping the fact silently — 24x the
busiest real page in the corpus, and that file is now 88 ms with its 46 runs
byte-identical. Counting uses raw_iter, which never dereferences the
entries.

Two upstream gaps are pinned by tests rather than papered over: NoView
(/F bit 6) annotations are included where poppler and mupdf suppress them,
and an annotation with no /AP yields no text because pdq does not synthesize
appearances from /V and /DA. Hidden (/F bit 2) is always excluded.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>