### PR TITLE
docs(text): state that runs are not clipped to the page box

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,13 @@ hayro interpreter `render` uses, and prints a JSON array to stdout:
   approximate glyph top (baseline minus 0.8 × `font_size`), `width` the sum
   of glyph advances, and `height` equals `font_size`; text made vertical by
   `/Rotate` yields a narrow, tall box instead.
+- **Runs are not clipped to the page.** A run's box may fall partly or wholly
+  outside `[0, page_width] x [0, page_height]`, including at negative
+  coordinates — content painted past the MediaBox, such as a wide table
+  overflowing the sheet, or a CropBox smaller than the MediaBox. Clip the
+  rectangle for display; do not filter the run out, or you lose that text.
+  mutool, pdf.js and poppler under `-cropbox` all discard it, so pdq's output
+  is a superset of theirs.
 - Word gaps encoded as TJ kerning offsets instead of space glyphs (LaTeX
   output) are synthesized as spaces, like poppler and pdf.js do: a gap of
   0.1–0.6 em past a glyph's advance becomes `' '`, anything wider starts a


### PR DESCRIPTION
Benchmarking against pdf-oxide flagged corpus/pdfjs/issue16316.pdf as a
suspected geometry bug: `pdq text` reports a 59.8x9.4 pt page and puts every
run at negative coordinates. It is not a bug. That page carries MediaBox
612x792 with CropBox [149.625 260.062 209.438 269.437], and hayro's
render_dimensions and initial_transform both derive from the
CropBox-intersected-MediaBox viewport — so text, render and dimensions agree
to the pixel, and a negative y correctly means "above the top of the
rendered image".

What was actually missing is the written invariant, and its absence is what
invites a consumer to filter runs to the page box. That filter is expensive:
55 of 1,413 text-bearing corpus files emit at least one fully out-of-box
run, 44 of them with no CropBox at all — content simply painted past the
sheet, such as the overflowing table columns common in court PDFs, where
dropping those runs costs about half the extracted characters.

Records the divergence too, so it is not re-litigated and "fixed" by
clipping: mutool, pdf.js and poppler under -cropbox all discard out-of-box
text, making pdq's output a superset. On issue16316.pdf pdq recovers 4,282
non-space characters and pdftotext 4,303, against mutool's 16.

No behaviour change.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>